### PR TITLE
Allow IPFS url to be used

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
-## [v0.5.6](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.5.6) 2024-12-28
+## [v0.5.6](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.5.6) 2025-01-09
 ### Added -
 ### Fixed 
-= Changed copy on landing page [Issue #2438](https://github.com/IntersectMBO/govtool/issues/2544)
+- Changed copy on landing page [Issue #2438](https://github.com/IntersectMBO/govtool/issues/2544)
+- Fixed support for IPFS [Issue #2438](https://github.com/IntersectMBO/govtool/issues/2495)
 
 ### Changed -
 ### Removed -

--- a/pdf-ui/src/lib/utils.js
+++ b/pdf-ui/src/lib/utils.js
@@ -5,7 +5,7 @@ import {
 } from '@emurgo/cardano-serialization-lib-asmjs';
 
 export const URL_REGEX =
-    /^(?:(?:https?:\/\/)?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:\/[^\s]*)?)|(?:ipfs:\/\/[a-f0-9]+(?:\/[a-zA-Z0-9_]+)*)$|^$/;
+    /^(?:(?:https?:\/\/)?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})(?:\/[^\s]*)?)|(?:ipfs:\/\/(?:[a-zA-Z0-9]+(?:\/[a-zA-Z0-9._-]+)*))$|^$/;
 
 export const formatIsoDate = (isoDate) => {
     if (!isoDate) return '';


### PR DESCRIPTION
## List of changes

- Fix 
- Changed regex to support IPFS standard for uploading files

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2495)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works