### PR TITLE
Add new field to migrate script

### DIFF
--- a/backend/src/api/bd-proposal-detail/content-types/bd-proposal-detail/schema.json
+++ b/backend/src/api/bd-proposal-detail/content-types/bd-proposal-detail/schema.json
@@ -39,7 +39,7 @@
       "type": "text"
     },
     "other_contract_type": {
-      "type": "string"
+      "type": "text"
     }
   }
 }

--- a/backend/src/api/migration/controllers/migration.js
+++ b/backend/src/api/migration/controllers/migration.js
@@ -383,6 +383,9 @@ module.exports = {
 				contract_type_name: item?.[
 					'<strong>Contracting</strong>: Please describe how you expect to be contracted.'
 				]?.replace(/\u200B/g, ''),
+				other_contract_type: item?.[
+					'Please describe what you have in mind.'
+				]?.replace(/\u200B/g, ''),
 			},
 			'api::bd-costing.bd-costing': {
 				preferred_currency: item?.['Preferred Currency']?.replace(

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -13,7 +13,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-03-30T09:06:19.329Z"
+    "x-generation-date": "2025-03-30T09:32:55.810Z"
   },
   "x-strapi-config": {
     "plugins": [],


### PR DESCRIPTION
## List of changes

- Add other_contract_type to migration script and make that field as long text

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
