### PR TITLE
feat: add is_active to true on migration creation

### DIFF
--- a/backend/src/api/migration/controllers/migration.js
+++ b/backend/src/api/migration/controllers/migration.js
@@ -409,6 +409,7 @@ module.exports = {
 				),
 			},
 			'api::bd.bd': {
+				is_active: true,
 				privacy_policy: true,
 				intersect_named_administrator:
 					item?.[


### PR DESCRIPTION
## List of changes

- add is_active to true on migration

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
