### PR TITLE
feat (#3355): Add Budget Proposals title when wallet is not connected

### DIFF
--- a/pdf-ui/src/pages/BudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/index.jsx
@@ -159,6 +159,14 @@ const ProposedBudgetDiscussion = () => {
                         justifyContent={'space-between'}
                         spacing={1}
                     >
+                        {!walletAPI?.address && (
+                            <Grid item xs={12} paddingBottom={2}>
+                                <Typography variant='h4' component='h1'>
+                                    Budget Proposals
+                                </Typography>
+                            </Grid>
+                        )}
+
                         {showAllActivated?.is_activated && (
                             <Grid item xs={12} paddingBottom={2}>
                                 <Button
@@ -341,12 +349,18 @@ const ProposedBudgetDiscussion = () => {
                                                             )}
                                                             id={`${ga?.attributes?.type_name}-radio-wrapper`}
                                                             data-testid={
-                                                                (ga?.attributes?.type_name ==
-                                                                    'None of these'
-                                                                        ? 'no-category'
-                                                                        : ga?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase()
-                                                                ) +`-radio-wrapper`}
-                                                            
+                                                                (ga?.attributes
+                                                                    ?.type_name ==
+                                                                'None of these'
+                                                                    ? 'no-category'
+                                                                    : ga?.attributes?.type_name
+                                                                          .replace(
+                                                                              /\s+/g,
+                                                                              '-'
+                                                                          )
+                                                                          .toLowerCase()) +
+                                                                `-radio-wrapper`
+                                                            }
                                                         >
                                                             <FormControlLabel
                                                                 control={
@@ -365,11 +379,18 @@ const ProposedBudgetDiscussion = () => {
                                                                         )}
                                                                         id={`${ga?.attributes?.type_name}-radio`}
                                                                         data-testid={
-                                                                            (ga?.attributes?.type_name ==
-                                                                                'None of these'
-                                                                                    ? 'no-category'
-                                                                                    : ga?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase()
-                                                                            ) +`-radio`
+                                                                            (ga
+                                                                                ?.attributes
+                                                                                ?.type_name ==
+                                                                            'None of these'
+                                                                                ? 'no-category'
+                                                                                : ga?.attributes?.type_name
+                                                                                      .replace(
+                                                                                          /\s+/g,
+                                                                                          '-'
+                                                                                      )
+                                                                                      .toLowerCase()) +
+                                                                            `-radio`
                                                                         }
                                                                     />
                                                                 }


### PR DESCRIPTION
## List of changes

- Add Budget Proposals title when wallet is not connected

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3355)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
