### PR TITLE
feat (#3352): add budget category label and value to budget card

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
@@ -130,17 +130,23 @@ const BudgetDiscussionCard = ({
                     backgroundColor: alpha('#FFFFFF', 0.3),
                     minHeight: '400px',
                 }}
-                
-                data-testid={isDraft? `draft-`+budgetDiscussion?.id+`-proposal`:
-                    `budget-discussion-`+
-                        (budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name =='None of these'
-                        ? 'no-category'
-                        : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase())
-                    +`-card`}
-                  
-            > 
+                data-testid={
+                    isDraft
+                        ? `draft-` + budgetDiscussion?.id + `-proposal`
+                        : `budget-discussion-` +
+                          (budgetDiscussion?.attributes?.bd_psapb?.data
+                              ?.attributes?.type_name?.data?.attributes
+                              ?.type_name == 'None of these'
+                              ? 'no-category'
+                              : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name
+                                    .replace(/\s+/g, '-')
+                                    .toLowerCase()) +
+                          `-card`
+                }
+            >
                 <CardHeader
-                    action={isDraft ? null : (
+                    action={
+                        isDraft ? null : (
                             <>
                                 <Tooltip title='Share'>
                                     <IconButton
@@ -286,28 +292,40 @@ const BudgetDiscussionCard = ({
                                     overflow: 'hidden',
                                     textOverflow: 'ellipsis',
                                 }}
-                                data-testid={isDraft?`draft-title`:`budget-discussion-title`}
-                            >
-                                {isDraft?
-                                   budgetDiscussion?.attributes?.draft_data?.bd_proposal_detail?.proposal_name
-                                   :budgetDiscussion?.attributes?.bd_proposal_detail?.data?.attributes?.proposal_name
-                                   
+                                data-testid={
+                                    isDraft
+                                        ? `draft-title`
+                                        : `budget-discussion-title`
                                 }
-                            </Typography>
-                            {budgetDiscussion?.attributes?.creator?.data?.attributes?.govtool_username?
-                                    <Typography
-                                variant='body2'
-                                component={'h5'}
-                                sx={{
-                                    color: (theme) =>
-                                        theme?.palette?.text?.darkPurple,
-                                }}
-                                mt={1}
-                                data-testid={isDraft?`draft-creator`:`budget-discussion-creator`}
                             >
-                                {}
-                                @{budgetDiscussion?.attributes?.creator?.data?.attributes?.govtool_username || ''}
-                            </Typography>:null}
+                                {isDraft
+                                    ? budgetDiscussion?.attributes?.draft_data
+                                          ?.bd_proposal_detail?.proposal_name
+                                    : budgetDiscussion?.attributes
+                                          ?.bd_proposal_detail?.data?.attributes
+                                          ?.proposal_name}
+                            </Typography>
+                            {budgetDiscussion?.attributes?.creator?.data
+                                ?.attributes?.govtool_username ? (
+                                <Typography
+                                    variant='body2'
+                                    component={'h5'}
+                                    sx={{
+                                        color: (theme) =>
+                                            theme?.palette?.text?.darkPurple,
+                                    }}
+                                    mt={1}
+                                    data-testid={
+                                        isDraft
+                                            ? `draft-creator`
+                                            : `budget-discussion-creator`
+                                    }
+                                >
+                                    @
+                                    {budgetDiscussion?.attributes?.creator?.data
+                                        ?.attributes?.govtool_username || ''}
+                                </Typography>
+                            ) : null}
                         </>
                     }
                 />
@@ -324,6 +342,26 @@ const BudgetDiscussionCard = ({
                         gap={2}
                         mb={3}
                     >
+                        <Box mt={2}>
+                            <Typography
+                                variant='caption'
+                                sx={{
+                                    color: (theme) =>
+                                        theme?.palette?.text?.grey,
+                                }}
+                                component={'p'}
+                            >
+                                Budget category
+                            </Typography>
+                            <Typography
+                                variant='body2'
+                                data-testid='budget-discussion-type'
+                            >
+                                {budgetDiscussion?.attributes?.bd_psapb?.data
+                                    ?.attributes?.type_name?.data?.attributes
+                                    ?.type_name || ''}
+                            </Typography>
+                        </Box>
                         <Box>
                             <Typography
                                 variant='caption'
@@ -332,14 +370,24 @@ const BudgetDiscussionCard = ({
                             >
                                 Proposal benefit
                             </Typography>
-                            <div data-testid={isDraft?`draft-proposal-benefit`:'proposal-benefit'} >
-                            <MarkdownTextComponent
-                                markdownText={
-                                    isDraft? budgetDiscussion?.attributes?.draft_data?.bd_psapb?.proposal_benefit
-                                    :budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.proposal_benefit
-                                
+                            <div
+                                data-testid={
+                                    isDraft
+                                        ? `draft-proposal-benefit`
+                                        : 'proposal-benefit'
                                 }
-                            /> 
+                            >
+                                <MarkdownTextComponent
+                                    markdownText={
+                                        isDraft
+                                            ? budgetDiscussion?.attributes
+                                                  ?.draft_data?.bd_psapb
+                                                  ?.proposal_benefit
+                                            : budgetDiscussion?.attributes
+                                                  ?.bd_psapb?.data?.attributes
+                                                  ?.proposal_benefit
+                                    }
+                                />
                             </div>
                         </Box>
                         <Box>
@@ -354,11 +402,18 @@ const BudgetDiscussionCard = ({
                                 variant='body2'
                                 component='p'
                                 color='text.darkPurple'
-                                data-testid={isDraft?'draft-budget-requested':'budget-requested-amount'}
-                            >₳ {
-                                isDraft? budgetDiscussion?.attributes?.draft_data?.bd_costing?.ada_amount
-                                :budgetDiscussion?.attributes?.bd_costing?.data?.attributes?.ada_amount
-                                || ''}
+                                data-testid={
+                                    isDraft
+                                        ? 'draft-budget-requested'
+                                        : 'budget-requested-amount'
+                                }
+                            >
+                                ₳{' '}
+                                {isDraft
+                                    ? budgetDiscussion?.attributes?.draft_data
+                                          ?.bd_costing?.ada_amount
+                                    : budgetDiscussion?.attributes?.bd_costing
+                                          ?.data?.attributes?.ada_amount || ''}
                             </Typography>
                         </Box>
                     </Box>
@@ -396,18 +451,17 @@ const BudgetDiscussionCard = ({
                                 component='p'
                                 color='text.black'
                                 data-testid={
-                                        isDraft
+                                    isDraft
                                         ? 'not-submitted-text'
                                         : 'proposed-date-wrapper'
                                 }
                             >
-                                {isDraft
-                                    ? 'Not submitted'
-                                    : `Proposed on: `}
-                                {!isDraft && (                                    
+                                {isDraft ? 'Not submitted' : `Proposed on: `}
+                                {!isDraft && (
                                     <span data-testid='proposed-date'>
                                         {formatIsoDate(
-                                            budgetDiscussion?.attributes?.createdAt
+                                            budgetDiscussion?.attributes
+                                                ?.createdAt
                                         )}
                                     </span>
                                 )}
@@ -427,13 +481,15 @@ const BudgetDiscussionCard = ({
                                             alignItems={'center'}
                                         >
                                             <IconButton
-                                               // data-testid={`proposal-${proposal?.id}-comment-count`}
+                                                // data-testid={`proposal-${proposal?.id}-comment-count`}
                                                 disabled={true}
                                             >
                                                 <StyledBadge
                                                     badgeContent={
-                                                        budgetDiscussion?.attributes
-                                                            ?.prop_comments_number || 0                                                       
+                                                        budgetDiscussion
+                                                            ?.attributes
+                                                            ?.prop_comments_number ||
+                                                        0
                                                     }
                                                     aria-label='comments'
                                                     showZero
@@ -444,13 +500,12 @@ const BudgetDiscussionCard = ({
                                     </Tooltip>
                                     {user &&
                                         user?.user?.id?.toString() ===
-                                            budgetDiscussion?.creator?.atributes?.user_id?.toString() &&
-                                          (
+                                            budgetDiscussion?.creator?.atributes?.user_id?.toString() && (
                                             <Tooltip title='Edit'>
                                                 <IconButton
                                                     aria-label='edit'
                                                     onClick={handleEditProposal}
-                                                   // data-testid={`proposal-${proposal?.id}-edit-button`}
+                                                    // data-testid={`proposal-${proposal?.id}-edit-button`}
                                                 >
                                                     <IconPencilAlt />
                                                 </IconButton>
@@ -463,7 +518,9 @@ const BudgetDiscussionCard = ({
                                 <Button
                                     variant='contained'
                                     fullWidth
-                                    onClick={() => startEdittingDraft(budgetDiscussion)}
+                                    onClick={() =>
+                                        startEdittingDraft(budgetDiscussion)
+                                    }
                                     data-testid={`draft-start-editing`}
                                     //`draft-`+budgetDiscussion?.id+`-start-editing`
                                 >
@@ -473,19 +530,34 @@ const BudgetDiscussionCard = ({
                                 <Box flexGrow={1}>
                                     <Link
                                         to={`/budget_discussion/${budgetDiscussion?.id}`}
-                                        data-testid={`budget-discussion-`+
-                                            (budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name =='None of these'
-                                            ? 'no-category'
-                                            : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase())
-                                        +`-view-details-link-wrapper`}
+                                        data-testid={
+                                            `budget-discussion-` +
+                                            (budgetDiscussion?.attributes
+                                                ?.bd_psapb?.data?.attributes
+                                                ?.type_name?.data?.attributes
+                                                ?.type_name == 'None of these'
+                                                ? 'no-category'
+                                                : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name
+                                                      .replace(/\s+/g, '-')
+                                                      .toLowerCase()) +
+                                            `-view-details-link-wrapper`
+                                        }
                                     >
                                         <Button
                                             variant='contained'
-                                            data-testid={`budget-discussion-`+
-                                                (budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name =='None of these'
-                                                ? 'no-category'
-                                                : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase())
-                                            +`-view-details`}
+                                            data-testid={
+                                                `budget-discussion-` +
+                                                (budgetDiscussion?.attributes
+                                                    ?.bd_psapb?.data?.attributes
+                                                    ?.type_name?.data
+                                                    ?.attributes?.type_name ==
+                                                'None of these'
+                                                    ? 'no-category'
+                                                    : budgetDiscussion?.attributes?.bd_psapb?.data?.attributes?.type_name?.data?.attributes?.type_name
+                                                          .replace(/\s+/g, '-')
+                                                          .toLowerCase()) +
+                                                `-view-details`
+                                            }
                                             fullWidth
                                         >
                                             View Details

--- a/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
+++ b/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
@@ -353,9 +353,29 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                             }
                                                         </Typography>
 
+                                                        <Box sx={{ mt: 4 }}>
+                                                            <BudgetDiscussionInfoSegment
+                                                                question={
+                                                                    'Budget category'
+                                                                }
+                                                                answer={
+                                                                    selectedVersion
+                                                                        ?.attributes
+                                                                        ?.bd_psapb
+                                                                        ?.data
+                                                                        ?.attributes
+                                                                        ?.type_name
+                                                                        ?.data
+                                                                        ?.attributes
+                                                                        ?.type_name ||
+                                                                    ''
+                                                                }
+                                                            />
+                                                        </Box>
+
                                                         <Box
                                                             sx={{
-                                                                mt: 4,
+                                                                mt: 3,
                                                             }}
                                                         >
                                                             <Typography

--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -316,24 +316,28 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                         ?.proposal_name
                                                 }
                                             </Typography>
-                                            <Typography
-                                                variant='body2'
-                                                component={'h5'}
-                                                sx={{
-                                                    color: (theme) =>
-                                                        theme?.palette?.text
-                                                            ?.black,
-                                                    mt: 1,
-                                                }}
-                                            >
-                                                @
-                                                {
-                                                    proposal?.attributes
-                                                        ?.creator?.data
-                                                        ?.attributes
-                                                        .govtool_username
-                                                }
-                                            </Typography>
+                                            {proposal?.attributes?.creator?.data
+                                                ?.attributes
+                                                .govtool_username ? (
+                                                <Typography
+                                                    variant='body2'
+                                                    component={'h5'}
+                                                    sx={{
+                                                        color: (theme) =>
+                                                            theme?.palette?.text
+                                                                ?.black,
+                                                        mt: 1,
+                                                    }}
+                                                >
+                                                    @
+                                                    {
+                                                        proposal?.attributes
+                                                            ?.creator?.data
+                                                            ?.attributes
+                                                            .govtool_username
+                                                    }
+                                                </Typography>
+                                            ) : null}
                                         </Grid>
 
                                         {/* SHARE BUTTON */}
@@ -753,7 +757,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                     ?.data?.attributes
                                                     ?.proposal_public_champion
                                             }
-                                            answerTestId='public-proposal-champion'   
+                                            answerTestId='public-proposal-champion'
                                         />
 
                                         <BudgetDiscussionInfoSegment
@@ -766,7 +770,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                     ?.data?.attributes
                                                     ?.social_handles
                                             }
-                                            answerTestId='social-handles' 
+                                            answerTestId='social-handles'
                                         />
                                     </Box>
                                     <Box
@@ -1019,7 +1023,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                         ?.data?.attributes
                                                         ?.currency_name
                                                 }
-                                                answerTestId={`costing-preferred-currency`} 
+                                                answerTestId={`costing-preferred-currency`}
                                             />
 
                                             <BudgetDiscussionInfoSegment
@@ -1178,9 +1182,11 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 backgroundColor: 'transparent',
                                             },
                                         }}
-                                        data-testid={showFullText
-                                            ? 'show-less-button'
-                                            : 'read-more-button'}
+                                        data-testid={
+                                            showFullText
+                                                ? 'show-less-button'
+                                                : 'read-more-button'
+                                        }
                                     >
                                         {showFullText
                                             ? 'Show less'


### PR DESCRIPTION
## List of changes

- Add budget label and value to bd card

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
