### PR TITLE
fix(#3392): fix signing data by calling the CIP-95 extension

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -26,6 +26,8 @@ changes.
 - [Fixed Cursor Jumping to End & No Soft Line Breaks](https://github.com/IntersectMBO/govtool/issues/3019)
 
 
+- [Sign data is not executed](https://github.com/IntersectMBO/govtool/issues/3392)
+
 ## [v0.6.1](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.6.1) 2025-02-12
 ### Fixed 
 - [Test ID for Sort Button](https://github.com/IntersectMBO/govtool/issues/2838)

--- a/pdf-ui/src/lib/helpers.js
+++ b/pdf-ui/src/lib/helpers.js
@@ -41,7 +41,7 @@ export const loginUserToApp = async ({
                 const messageUtf = `To proceed, please sign this data to verify your identity. This ensures that the action is secure and confirms your identity.`;
                 const messageHex = utf8ToHex(messageUtf);
 
-                const signedData = await wallet.signData(
+                const signedData = await wallet?.cip95.signData(
                     stakeKeyHash,
                     messageHex
                 );


### PR DESCRIPTION
## List of changes

- Sign data is part of the [CIP-95 extension](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0095#apicip95signdataaddr-address--drepid-payload-bytes-promisedatasignature) which is the one that is required by GovTool

### Important!
I've tested this one against already installed node module in GovTool - @nebojsact Could you please verify before merging if that fix is working as expected under your local stack?

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3392)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
