### PR TITLE
fix: check for secure cookie flag

### DIFF
--- a/backend/src/extensions/users-permissions/strapi-server.js
+++ b/backend/src/extensions/users-permissions/strapi-server.js
@@ -210,7 +210,7 @@ module.exports = (plugin) => {
 					}),
 					{
 						httpOnly: true,
-						secure: process.env.NODE_ENV === 'production',
+						secure: false, //process.env.NODE_ENV === 'production',
 						signed: true,
 						overwrite: true,
 						sameSite: 'Lax',
@@ -253,7 +253,8 @@ module.exports = (plugin) => {
 					}),
 					{
 						httpOnly: true,
-						secure: process.env.NODE_ENV === 'production',
+						// secure: process.env.NODE_ENV === 'production',
+						secure: false, //process.env.NODE_ENV === 'production',
 						signed: true,
 						overwrite: true,
 						sameSite: 'Lax',
@@ -331,7 +332,8 @@ module.exports = (plugin) => {
 			});
 			ctx.cookies.set('refreshToken', refreshToken, {
 				httpOnly: true,
-				secure: process.env.NODE_ENV === 'production',
+				// secure: process.env.NODE_ENV === 'production',
+				secure: false, //process.env.NODE_ENV === 'production',
 				signed: true,
 				overwrite: true,
 				sameSite: 'Lax',


### PR DESCRIPTION
## List of changes

- Change secure cookie flag to false to check on deployed version

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
