### PR TITLE
fix: handle comments transfer to new version and refresh on reply

### DIFF
--- a/backend/src/api/bd/controllers/bd.js
+++ b/backend/src/api/bd/controllers/bd.js
@@ -148,42 +148,55 @@ module.exports = createCoreController("api::bd.bd", ({ strapi }) => ({
       });
 
       if (latestVersionId) {
-        await strapi.entityService.update("api::bd.bd", latestVersionId, {
-          data: { is_active: false },
-        });
-        const poll = await strapi.entityService.findMany(
-          "api::bd-poll.bd-poll",
-          { filters: { bd_proposal_id: latestVersionId } }
-        );
-        if (poll.length > 0) {
-          await strapi.entityService.update(
-            "api::bd-poll.bd-poll",
-            poll[0].id,
-            { data: { bd_proposal_id: createdEntry.id.toString() } }
-          );
-        }
-        const comments = await strapi.entityService.findMany(
-          "api::comment.comment",
-          { filters: { bd_proposal_id: latestVersionId } }
-        );
-        if (comments.length > 0) {
-          for (const comment of comments) {
-            await strapi.entityService.update(
-              "api::comment.comment",
-              comment.id,
-              {
-                data: {
-                  bd_proposal_id: createdEntry.id.toString(),
-                },
-              }
-            );
-          }
-        }
-      } else {
-        await strapi.entityService.create("api::bd-poll.bd-poll", {
-          data: { bd_proposal_id: createdEntry.id.toString() },
-        });
-      }
+			await strapi.entityService.update('api::bd.bd', latestVersionId, {
+				data: { is_active: false },
+			});
+
+			const latestVersionProposalData =
+				await strapi.entityService.findOne(
+					'api::bd.bd',
+					latestVersionId
+				);
+			await strapi.entityService.update('api::bd.bd', createdEntry?.id, {
+				data: {
+					prop_comments_number:
+						latestVersionProposalData?.prop_comments_number || 0,
+				},
+			});
+
+			const poll = await strapi.entityService.findMany(
+				'api::bd-poll.bd-poll',
+				{ filters: { bd_proposal_id: latestVersionId } }
+			);
+			if (poll.length > 0) {
+				await strapi.entityService.update(
+					'api::bd-poll.bd-poll',
+					poll[0].id,
+					{ data: { bd_proposal_id: createdEntry.id.toString() } }
+				);
+			}
+			const comments = await strapi.entityService.findMany(
+				'api::comment.comment',
+				{ filters: { bd_proposal_id: latestVersionId } }
+			);
+			if (comments.length > 0) {
+				for (const comment of comments) {
+					await strapi.entityService.update(
+						'api::comment.comment',
+						comment.id,
+						{
+							data: {
+								bd_proposal_id: createdEntry.id.toString(),
+							},
+						}
+					);
+				}
+			}
+		} else {
+			await strapi.entityService.create('api::bd-poll.bd-poll', {
+				data: { bd_proposal_id: createdEntry.id.toString() },
+			});
+		}
 
       return createdEntry;
     } catch (error) {

--- a/pdf-ui/src/components/CommentCard/index.jsx
+++ b/pdf-ui/src/components/CommentCard/index.jsx
@@ -31,7 +31,12 @@ import Subcomponent from './Subcomponent';
 import { isCommentRestricted } from '../../lib/helpers';
 import UsernameSection from './UsernameSection';
 
-const CommentCard = ({ comment, proposal, fetchComments }) => {
+const CommentCard = ({
+    comment,
+    proposal,
+    fetchComments,
+    setRefetchProposal,
+}) => {
     const {
         setLoading,
         walletAPI,
@@ -117,6 +122,7 @@ const CommentCard = ({ comment, proposal, fetchComments }) => {
             loadSubComments(1);
             setCommentHasReplays(true);
             setShowReply(false);
+            setRefetchProposal(true);
         } catch (error) {
             console.error(error);
         } finally {

--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -71,6 +71,7 @@ const SingleBudgetDiscussion = ({ id }) => {
     const [ownProposalModal, setOwnProposalModal] = useState(false);
     const [activePoll, setActivePoll] = useState(null);
     const [showCreateBDDialog, setShowCreateBDDialog] = useState(false);
+    const [refetchProposal, setRefetchProposal] = useState(false);
 
     // Read More / Show Less logic
     const [showFullText, setShowFullText] = useState(false);
@@ -261,6 +262,13 @@ const SingleBudgetDiscussion = ({ id }) => {
             fetchComments(1);
         }
     }, [id, mounted]);
+
+    useEffect(() => {
+        if (mounted && refetchProposal) {
+            fetchProposal(id);
+            setRefetchProposal(false);
+        }
+    }, [mounted, refetchProposal, id]);
 
     useEffect(() => {
         if (mounted) {
@@ -918,7 +926,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 }
                                                 answerTestId={`proposal-key-dependencies`}
                                             />
-                                            
+
                                             <BudgetDiscussionInfoSegment
                                                 question={
                                                     'How will this proposal be maintained and supported after initial development?'
@@ -1177,17 +1185,22 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 }
                                                 answerTestId={`include-as-auditor`}
                                             />
-                                            {proposal?.attributes?.intersect_named_administrator?'':
+                                            {proposal?.attributes
+                                                ?.intersect_named_administrator ? (
+                                                ''
+                                            ) : (
                                                 <BudgetDiscussionInfoSegment
                                                     question='Please provide further information to help inform DReps. Who is the vendor and what services are they providing?'
                                                     answer={
                                                         proposal?.attributes
-                                                            ?.intersect_admin_further_text ||''
+                                                            ?.intersect_admin_further_text ||
+                                                        ''
                                                     }
                                                     answerTestId={
                                                         'intersect-admin-further-text'
                                                     }
-                                                />}
+                                                />
+                                            )}
                                         </Box>
                                     )}
                                     <Button
@@ -1455,6 +1468,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                     comment={comment}
                                     proposal={proposal}
                                     fetchComments={fetchComments}
+                                    setRefetchProposal={setRefetchProposal}
                                 />
                             </Box>
                         ))}


### PR DESCRIPTION
## List of changes

- Fix comments transfer and refetch on reply

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
