### PR TITLE
Fix Group info are not passed on the proposal page #3445

### DIFF
--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -42,6 +42,7 @@ import {
     getComments,
     getBudgetDiscussion,
     getBudgetDiscussionPoll,
+    getCountryList,
 } from '../../../lib/api';
 import { formatIsoDate, openInNewTab } from '../../../lib/utils';
 import ProposalOwnModal from '../../../components/ProposalOwnModal';
@@ -72,6 +73,7 @@ const SingleBudgetDiscussion = ({ id }) => {
     const [activePoll, setActivePoll] = useState(null);
     const [showCreateBDDialog, setShowCreateBDDialog] = useState(false);
     const [refetchProposal, setRefetchProposal] = useState(false);
+    const [allCountries, setAllCountries] = useState([]);
 
     // Read More / Show Less logic
     const [showFullText, setShowFullText] = useState(false);
@@ -84,7 +86,20 @@ const SingleBudgetDiscussion = ({ id }) => {
         let origin = domain.origin;
         setProposalLink(`${origin}/budget_discussion/`);
     }, [proposalLink]);
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                if (!allCountries.length) {
+                    const countriesResponse = await getCountryList();
+                    setAllCountries(countriesResponse?.data || []);
+                }
+            } catch (error) {
+                console.error('Error fetching data:', error);
+            }
+        };
 
+        fetchData();
+    }, []);
     const disableShareClick = () => {
         setDisableShare(true);
         setTimeout(() => {
@@ -767,7 +782,88 @@ const SingleBudgetDiscussion = ({ id }) => {
                                             }
                                             answerTestId='public-proposal-champion'
                                         /> */}
+                                    {proposal?.attributes
+                                        ?.bd_proposal_ownership?.data?.attributes
+                                        ?.submited_on_behalf === 'Company' ? (
+                                        <Box>
+                                            <BudgetDiscussionInfoSegment
+                                                question='Company Name'
+                                                answer={
+                                                    proposal?.attributes
+                                                        ?.bd_proposal_ownership?.data?.attributes
+                                                        ?.company_name || ''
+                                                }
+                                                answerTestId='company-name-content'
+                                            />
 
+                                            <BudgetDiscussionInfoSegment
+                                                question='Company Domain Name'
+                                                answer={
+                                                    proposal?.attributes
+                                                        ?.bd_proposal_ownership?.data?.attributes
+                                                        ?.company_domain_name ||
+                                                    ''
+                                                }
+                                                answerTestId='company-domain-name-content'
+                                            />
+                                            <BudgetDiscussionInfoSegment
+                                                question='Country of Incorporation'
+                                                answer={
+                                                    allCountries.find(
+                                                        (country) =>
+                                                            country.id ===
+                                                        proposal?.attributes.bd_proposal_ownership.data.attributes.be_country.data.id
+                                                    )?.attributes
+                                                        ?.country_name ||
+                                                    'Error'
+                                                }
+                                                answerTestId='country-of-incorporation-content'
+                                            />
+                                        </Box>
+                                    ) : (
+                                        ''
+                                    )}
+                                    {proposal?.attributes
+                                        ?.bd_proposal_ownership?.data?.attributes
+                                        ?.submited_on_behalf === 'Group' ? 
+                                        
+                                        
+                                        (
+                                        <Box>
+                                            <BudgetDiscussionInfoSegment
+                                                question='Group Name'
+                                                answer={proposal?.attributes
+                                                        ?.bd_proposal_ownership?.data?.attributes
+                                                        ?.group_name || ''
+                                                }
+                                                answerTestId='group-name-content'
+                                            />
+
+                                            <BudgetDiscussionInfoSegment
+                                                question='Type of Group'
+                                                answer={
+                                                    proposal?.attributes
+                                                        ?.bd_proposal_ownership?.data?.attributes
+                                                        ?.type_of_group || ''
+                                                }
+                                                answerTestId='group-type-content'
+                                            />
+
+                                            <BudgetDiscussionInfoSegment
+                                                question='Key Information to Identify
+                                                Group'
+                                                answer={
+                                                    proposal?.attributes
+                                                        ?.bd_proposal_ownership?.data?.attributes
+                                                        ?.key_info_to_identify_group ||
+                                                    ''
+                                                }
+                                                answerTestId='group-identity-information-content'
+                                            />
+                                        </Box>
+                                    ) : (
+                                        ''
+                                    )}
                                         <BudgetDiscussionInfoSegment
                                             question={
                                                 'What social handles would you like to be used? E.g. Github, X'


### PR DESCRIPTION
## List of changes

Fix Group info are not passed on the proposal page #3445

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
