### PR TITLE
feat(#3331): rename sort options to newest and oldest

### DIFF
--- a/pdf-ui/src/pages/BudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/index.jsx
@@ -471,9 +471,7 @@ const ProposedBudgetDiscussion = () => {
                                     data-testid='sort-button'
                                 >
                                     Sort:{' '}
-                                    {sortType === 'desc'
-                                        ? 'Last modified (desc)'
-                                        : 'Last modified (asc)'}
+                                    {sortType === 'desc' ? 'Newest' : 'Oldest'}
                                 </Button>
                             </Box>
                         </Grid>


### PR DESCRIPTION
## List of changes

- Rename sorting options to newest and oldest

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
