### PR TITLE
3446 update of step 7 name

### DIFF
--- a/backend/src/api/bd/controllers/bd.js
+++ b/backend/src/api/bd/controllers/bd.js
@@ -227,6 +227,8 @@ module.exports = createCoreController("api::bd.bd", ({ strapi }) => ({
       delete entity?.creator?.is_validated;
       delete entity?.creator?.password;
       delete entity?.creator?.confirmed;
+      delete entity?.creator?.confirmationToken;
+		delete entity?.creator?.resetPasswordToken;
     }
 
     const sanitizedEntity = await this.sanitizeOutput(entity, ctx);
@@ -234,32 +236,39 @@ module.exports = createCoreController("api::bd.bd", ({ strapi }) => ({
   },
 
   async find(ctx) {
-    const query = ctx.request.query;
+		const query = ctx.request.query;
 
-    const { results, pagination } = await strapi.service("api::bd.bd").find({
-      ...query,
-    });
+		const { results, pagination } = await strapi
+			.service('api::bd.bd')
+			.find({
+				...query,
+			});
 
-    const sanitizedResults = results.map((entity) => {
-      if (entity?.bd_contact_information) {
-        delete entity.bd_contact_information;
-      }
+		const sanitizedResults = results.map((entity) => {
+			if (entity?.bd_contact_information) {
+				delete entity.bd_contact_information;
+			}
 
-      if (entity?.creator) {
-        delete entity?.creator?.username;
-        delete entity?.creator?.email;
-        delete entity?.creator?.provider;
-        delete entity?.creator?.blocked;
-        delete entity?.creator?.createdAt;
-        delete entity?.creator?.updatedAt;
-        delete entity?.creator?.is_validated;
-        delete entity?.creator?.password;
-        delete entity?.creator?.confirmed;
-      }
-      return entity;
-    });
+			if (entity?.creator) {
+				delete entity?.creator?.username;
+				delete entity?.creator?.email;
+				delete entity?.creator?.provider;
+				delete entity?.creator?.blocked;
+				delete entity?.creator?.createdAt;
+				delete entity?.creator?.updatedAt;
+				delete entity?.creator?.is_validated;
+				delete entity?.creator?.password;
+				delete entity?.creator?.confirmed;
+				delete entity?.creator?.confirmationToken;
+				delete entity?.creator?.resetPasswordToken;
+			}
+			return entity;
+		});
 
-    const sanitizedOutput = await this.sanitizeOutput(sanitizedResults, ctx);
-    return this.transformResponse(sanitizedOutput, { pagination });
+		const transformed = this.transformResponse(sanitizedResults, {
+			pagination,
+		});
+
+		return transformed;
   },
 }));

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -13,7 +13,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-04-22T14:25:34.817Z"
+    "x-generation-date": "2025-04-23T09:24:01.563Z"
   },
   "x-strapi-config": {
     "plugins": [],

--- a/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
@@ -30,6 +30,7 @@ import { useAppContext } from '../../context/context';
 import { correctVoteAdaFormat, formatIsoDate } from '../../lib/utils';
 import EditProposalDialog from '../EditProposalDialog';
 import MarkdownTextComponent from '../MarkdownTextComponent';
+import CreateBudgetDiscussionDialog from '../CreateBudgetDiscussionDialog';
 
 const BudgetDiscussionCard = ({
     budgetDiscussion,
@@ -53,13 +54,13 @@ const BudgetDiscussionCard = ({
     }, [budgetDiscussionLink]);
 
     const handleEditProposal = () => {
-        // pokrenuti popunjavanje sa predefinisam podacime ... ne edit
-        // setOpenEditDialog(true);
+        // Open edit modal
+        setOpenEditDialog(true);
     };
 
     const handleCloseEditDialog = () => {
-        // zatvori stepper za edit
-        //  setOpenEditDialog(false);
+        // Close edit modal
+        setOpenEditDialog(false);
     };
 
     const filterProps = ({ draft, submitted, ...rest }) => rest;
@@ -505,12 +506,12 @@ const BudgetDiscussionCard = ({
                                     </Tooltip>
                                     {user &&
                                         user?.user?.id?.toString() ===
-                                            budgetDiscussion?.creator?.atributes?.user_id?.toString() && (
+                                            budgetDiscussion?.attributes?.creator?.data?.id?.toString() && (
                                             <Tooltip title='Edit'>
                                                 <IconButton
                                                     aria-label='edit'
                                                     onClick={handleEditProposal}
-                                                    // data-testid={`proposal-${proposal?.id}-edit-button`}
+                                                    data-testid={`budget-proposals-${budgetDiscussion?.attributes?.master_id}-edit-button`}
                                                 >
                                                     <IconPencilAlt />
                                                 </IconButton>
@@ -648,19 +649,13 @@ const BudgetDiscussionCard = ({
                 <CardContentComponent budgetDiscussion={budgetDiscussion} />
             </CardStatusBadge>
 
-            {openEditDialog && (
-                <Box>Edit</Box>
-                // <EditProposalDialog
-                //     proposal={proposal}
-                //     openEditDialog={openEditDialog}
-                //     handleCloseEditDialog={handleCloseEditDialog}
-                //     setMounted={() => {}}
-                //     onUpdate={() =>
-                //         navigate(`/proposal_discussion/${proposal?.id}`)
-                //     }
-                //     setShouldRefresh={setShouldRefresh}
-                // />
-            )}
+            {openEditDialog ? (
+                <CreateBudgetDiscussionDialog
+                    open={openEditDialog}
+                    onClose={handleCloseEditDialog}
+                    current_bd_id={budgetDiscussion?.attributes?.master_id}
+                />
+            ) : null}
         </div>
     );
 };

--- a/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionInfo.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionInfo.jsx
@@ -49,7 +49,7 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                             >
                                 <Typography variant='h4' gutterBottom>
                                     Decide if you want to use Existing Draft or
-                                    Create new budget discussion
+                                    Create new budget proposal
                                 </Typography>
                             </Box>
 
@@ -69,7 +69,7 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                                     onClick={() => setStep(2)}
                                     data-testid='create-new-budget-discussion-button'
                                 >
-                                    Create new Budget Discussion
+                                    Create new Budget Proposal
                                 </Button>
                             </Box>
                         </CardContent>
@@ -106,16 +106,21 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
 
                             <Box color={(theme) => theme.palette.text.grey}>
                                 <Typography variant='body1' gutterBottom>
-                                    This process is open to any individual or organization within the Cardano ecosystem that wishes to submit a proposal related to the Cardano blockchain ecosystem for inclusion in a Cardano Budget facilitated by Intersect.
+                                    This process is open to any individual or
+                                    organization within the Cardano ecosystem
+                                    that wishes to submit a proposal related to
+                                    the Cardano blockchain ecosystem for
+                                    inclusion in a Cardano Budget facilitated by
+                                    Intersect.
                                 </Typography>
                                 <List
                                     sx={{
                                         listStyleType: 'disc',
                                         marginLeft: 2,
                                         textAlign: 'justify',
-                                        marginBottom:0,
+                                        marginBottom: 0,
                                     }}
-                                 >
+                                >
                                     <ListItem
                                         sx={{
                                             textAlign: 'justify',
@@ -127,9 +132,11 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                                         <Typography
                                             variant='body1'
                                             gutterBottom
-                                            
                                         >
-                                            All proposals, except private contact details, will be made public to facilitate community and DRep review and decision-making.
+                                            All proposals, except private
+                                            contact details, will be made public
+                                            to facilitate community and DRep
+                                            review and decision-making.
                                         </Typography>
                                     </ListItem>
                                     <ListItem
@@ -144,56 +151,27 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                                             variant='body1'
                                             gutterBottom
                                         >
-                                            If you have submitted or are already receiving funding for your proposal from Project Catalyst, you are not eligible to apply for funding via this process.
+                                            If you have submitted or are already
+                                            receiving funding for your proposal
+                                            from Project Catalyst, you are not
+                                            eligible to apply for funding via
+                                            this process.
                                         </Typography>
                                     </ListItem>
-                                    </List>
-                                    <Typography variant='body1' gutterBottom>
-                                    If you have made a prior proposal submission through an Intersect Committee, you will need to either:
-                                    </Typography>
-                                    <List sx={{
-                                        listStyleType: 'disc',
-                                        marginLeft: 2,
-                                        textAlign: 'justify',
-                                        marginBottom:0,
-                                    }}
-                                    >
-                                    <ListItem
-                                        sx={{
-                                            textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
-                                        >
-                                         Resubmit your proposal through this new process, this ensures all proposals will have the same information, look and feel for DRep reconciliation;
-                                        </Typography>
-                                    </ListItem>
-                                    <ListItem
-                                        sx={{
-                                            textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
-                                        >
-                                         Or confirm if you would like Intersect to repurpose the information previously provided. Please note that we may not have enough details to complete the submission on your behalf, and any missing information will be shown as ‘not provided’. You can confirm this by contacting operational-services@intersectmbo.org with the following information:
-                                        </Typography>
-                                    </ListItem>
-                                    <List sx={{
+                                </List>
+                                <Typography variant='body1' gutterBottom>
+                                    If you have made a prior proposal submission
+                                    through an Intersect Committee, you will
+                                    need to either:
+                                </Typography>
+                                <List
+                                    sx={{
                                         listStyleType: 'disc',
                                         marginLeft: 2,
                                         textAlign: 'justify',
                                         marginBottom: 0,
-                                    }}>
+                                    }}
+                                >
                                     <ListItem
                                         sx={{
                                             textAlign: 'justify',
@@ -206,7 +184,11 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                                             variant='body1'
                                             gutterBottom
                                         >
-                                        Proposal Name
+                                            Resubmit your proposal through this
+                                            new process, this ensures all
+                                            proposals will have the same
+                                            information, look and feel for DRep
+                                            reconciliation;
                                         </Typography>
                                     </ListItem>
                                     <ListItem
@@ -221,79 +203,136 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                                             variant='body1'
                                             gutterBottom
                                         >
-                                        Proposer Name
+                                            Or confirm if you would like
+                                            Intersect to repurpose the
+                                            information previously provided.
+                                            Please note that we may not have
+                                            enough details to complete the
+                                            submission on your behalf, and any
+                                            missing information will be shown as
+                                            ‘not provided’. You can confirm this
+                                            by contacting
+                                            operational-services@intersectmbo.org
+                                            with the following information:
                                         </Typography>
                                     </ListItem>
-                                    <ListItem
+                                    <List
                                         sx={{
+                                            listStyleType: 'disc',
+                                            marginLeft: 2,
                                             textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
+                                            marginBottom: 0,
                                         }}
                                     >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
                                         >
-                                        Intersect Committee that it has been aligned / submitted to
-                                        </Typography>
-                                    </ListItem>
-                                    <ListItem
-                                        sx={{
-                                            textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Proposal Name
+                                            </Typography>
+                                        </ListItem>
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
                                         >
-                                        Submission Date (approximate)
-                                        </Typography>
-                                    </ListItem>
-                                    <ListItem
-                                        sx={{
-                                            textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Proposer Name
+                                            </Typography>
+                                        </ListItem>
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
                                         >
-                                        Intersect POC (if known)
-                                        </Typography>
-                                    </ListItem>
-                                    <ListItem
-                                        sx={{
-                                            textAlign: 'justify',
-                                            display: 'list-item',
-                                            paddingY: 0,
-                                            marginY: 0,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Intersect Committee that it has
+                                                been aligned / submitted to
+                                            </Typography>
+                                        </ListItem>
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
                                         >
-                                        Brief Proposal Description
-                                        </Typography>
-                                    </ListItem>
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Submission Date (approximate)
+                                            </Typography>
+                                        </ListItem>
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
+                                        >
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Intersect POC (if known)
+                                            </Typography>
+                                        </ListItem>
+                                        <ListItem
+                                            sx={{
+                                                textAlign: 'justify',
+                                                display: 'list-item',
+                                                paddingY: 0,
+                                                marginY: 0,
+                                            }}
+                                        >
+                                            <Typography
+                                                variant='body1'
+                                                gutterBottom
+                                            >
+                                                Brief Proposal Description
+                                            </Typography>
+                                        </ListItem>
                                     </List>
                                 </List>
                                 <Typography variant='body1' gutterBottom>
-                                   The more information you provide, the better we will be able to help you.
+                                    The more information you provide, the better
+                                    we will be able to help you.
                                 </Typography>
                                 <Typography variant='body1' gutterBottom>
-                                    All proposals will be made public (barring any private contact information). Intersect committees may provide advice or recommendations to help refine or improve your proposal. Committees can support DReps with advice, guidance, and recommendations to aid in their decision-making wherever helpful.
+                                    All proposals will be made public (barring
+                                    any private contact information). Intersect
+                                    committees may provide advice or
+                                    recommendations to help refine or improve
+                                    your proposal. Committees can support DReps
+                                    with advice, guidance, and recommendations
+                                    to aid in their decision-making wherever
+                                    helpful.
                                 </Typography>
                             </Box>
-                            <StepperActionButtons 
+                            <StepperActionButtons
                                 onClose={onClose}
                                 onSaveDraft={handleSaveDraft}
                                 showSaveDraft={false}
@@ -307,15 +346,19 @@ const BudgetDiscussionInfo = ({setStep, step, onClose, setBudgetDiscussionData, 
                 )}
             </Box>
             <Box mt={4}>
-                {<BudgetDiscussionsList
-                    isDraft={true}
-                    startEdittingDraft={(budgetDiscussion) => {
-                       setStep(2);
-                       setBudgetDiscussionData(budgetDiscussion?.attributes.draft_data);
-                       setSelectedDraftId(budgetDiscussion?.id);
-                    }}
-                    statusList={[]}
-                />}
+                {
+                    <BudgetDiscussionsList
+                        isDraft={true}
+                        startEdittingDraft={(budgetDiscussion) => {
+                            setStep(2);
+                            setBudgetDiscussionData(
+                                budgetDiscussion?.attributes.draft_data
+                            );
+                            setSelectedDraftId(budgetDiscussion?.id);
+                        }}
+                        statusList={[]}
+                    />
+                }
             </Box>
         </Box>
     );

--- a/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionSubmit/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionSubmit/index.jsx
@@ -57,7 +57,7 @@ const BudgetDiscussionSubmit = ({
                             }}
                         >
                             <Typography variant='h4' gutterBottom mb={2}>
-                                Submit
+                                Privacy Policy & Terms of Use
                             </Typography>
                             <Box color={(theme) => theme.palette.text.grey}>
                                 <FormControlLabel

--- a/pdf-ui/src/components/BudgetDiscussionParts/ProposalOwnership/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionParts/ProposalOwnership/index.jsx
@@ -431,10 +431,10 @@ const ProposalOwnership = ({
                             <FormControlLabel
                                 control={
                                     <Checkbox
-                                        checked={
+                                        checked={Boolean(
                                             currentBudgetDiscussionData
                                                 ?.bd_proposal_ownership?.agreed
-                                        }
+                                        )}
                                         onChange={(e) =>
                                             handleDataChange(e, 'agreed')
                                         }

--- a/pdf-ui/src/pages/BudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/index.jsx
@@ -192,9 +192,9 @@ const ProposedBudgetDiscussion = () => {
                                             bd_type: null,
                                         });
                                     }}
-                                    data-testid='back-to-budget-discussion-button'
+                                    data-testid='back-to-budget-proposals-button'
                                 >
-                                    Back to Budget Discussion
+                                    Back to Budget Proposals
                                 </Button>
                             </Grid>
                         )}
@@ -340,7 +340,7 @@ const ProposedBudgetDiscussion = () => {
                                                         mb: 1,
                                                     }}
                                                 >
-                                                    Budget Discussion types
+                                                    Budget categories
                                                 </Typography>
                                                 <Divider
                                                     sx={{
@@ -471,7 +471,9 @@ const ProposedBudgetDiscussion = () => {
                                     data-testid='sort-button'
                                 >
                                     Sort:{' '}
-                                    {sortType === 'desc' ? 'Newest' : 'Oldest'}
+                                    {sortType === 'desc'
+                                        ? 'Newest first'
+                                        : 'Oldest first'}
                                 </Button>
                             </Box>
                         </Grid>


### PR DESCRIPTION
## List of changes

- Updated step 7 name to privacy policy
- Updated back to budget discussion button name to back to budget proposals
- Updated button Create new Budget Discussion to Create new Budget Proposal
- Updated create new Budget discussion text in draft screen to Create new Budget proposal text
- Updated Budget discussion types filter name to Budget categories as per Figma
- Updated Newest and Oldest sort names to Newest first and Oldest first as per Figma
- Add edit iconButton to BudgetDiscussionCard for the user ehich created it and also handle logic to open that edit modal
- Handle Boolean value for pre-check on Checkbox for agreement on first step of the form

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3446)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
