### PR TITLE
feat(#3353): add my proposals filter to bd

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionsList/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionsList/index.jsx
@@ -23,6 +23,7 @@ import { getBudgetDiscussionDrafts, getBudgetDiscussions } from '../../lib/api';
 import { settings } from '../../lib/carouselSettings';
 import { useTheme } from '@emotion/react';
 import { BudgetDiscussionsCard } from '..';
+import { useAppContext } from '../../context/context';
 
 const BudgetDiscussionsList = ({
     currentBudgetDiscussionType = null,
@@ -37,6 +38,7 @@ const BudgetDiscussionsList = ({
     isAllProposalsListEmpty,
     setIsAllProposalsListEmpty,
     filteredBudgetDiscussionTypeList,
+    proposalOwnerFilter = null,
 }) => {
     const theme = useTheme();
     const sliderRef = useRef(null);
@@ -52,6 +54,8 @@ const BudgetDiscussionsList = ({
     const isSm = useMediaQuery(theme.breakpoints.only('sm'));
     const isMd = useMediaQuery(theme.breakpoints.only('md'));
     const isLg = useMediaQuery(theme.breakpoints.only('lg'));
+
+    const { user } = useAppContext();
 
     let extraBoxes = 0;
 
@@ -81,7 +85,7 @@ const BudgetDiscussionsList = ({
                     currentBudgetDiscussionType?.id
                 }&filters[$and][2][bd_proposal_detail][proposal_name][$containsi]=${
                     debouncedSearchValue || ''
-                }&pagination[page]=${page}&pagination[pageSize]=25&sort[createdAt]=${
+                }${proposalOwnerFilter?.id === 'all-proposals' ? '' : '&filters[$and][3][creator]=' + user?.user?.id}&pagination[page]=${page}&pagination[pageSize]=25&sort[createdAt]=${
                     sortType
                 }&populate[0]=bd_costing&populate[1]=bd_psapb.type_name&populate[2]=bd_proposal_detail&populate[3]=creator`;
                 const { budgetDiscussions, pgCount, total } =
@@ -116,6 +120,7 @@ const BudgetDiscussionsList = ({
         isDraft ? null : statusList,
         showAllActivated,
         currentBudgetDiscussionType,
+        proposalOwnerFilter?.id,
     ]);
 
     useEffect(() => {
@@ -210,11 +215,18 @@ const BudgetDiscussionsList = ({
                                         }));
                                     }
                                 }}
-                                data-testid={isDraft?'draft-show-all-button':
-                                    (currentBudgetDiscussionType?.attributes?.type_name ==
-                                    'None of these'
-                                        ? 'no-category-show-all-button'
-                                        : currentBudgetDiscussionType?.attributes?.type_name.replace(/\s+/g, '-').toLowerCase() +'-show-all-button')}
+                                data-testid={
+                                    isDraft
+                                        ? 'draft-show-all-button'
+                                        : currentBudgetDiscussionType
+                                                ?.attributes?.type_name ==
+                                            'None of these'
+                                          ? 'no-category-show-all-button'
+                                          : currentBudgetDiscussionType?.attributes?.type_name
+                                                .replace(/\s+/g, '-')
+                                                .toLowerCase() +
+                                            '-show-all-button'
+                                }
                             >
                                 {setShowAllActivated
                                     ? setShowAllActivated?.is_activated

--- a/pdf-ui/src/pages/BudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/index.jsx
@@ -25,6 +25,7 @@ import {
     CardContent,
     Stack,
     alpha,
+    Radio,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { getBudgetDiscussionTypes } from '../../lib/api';
@@ -36,6 +37,11 @@ import { useAppContext } from '../../context/context';
 import { loginUserToApp } from '../../lib/helpers';
 import { useLocation } from 'react-router-dom';
 import { ScrollToTop } from '../../lib/hooks';
+
+let proposalsOwnersList = [
+    { id: 'my-proposals', label: 'My Proposals' },
+    { id: 'all-proposals', label: 'All Proposals' },
+];
 
 const ProposedBudgetDiscussion = () => {
     const location = useLocation();
@@ -50,6 +56,12 @@ const ProposedBudgetDiscussion = () => {
         addErrorAlert,
         addChangesSavedAlert,
     } = useAppContext();
+
+    const defaultOwnerFilterId = 'all-proposals';
+    const defaultOwnerFilter = proposalsOwnersList?.find(
+        (f) => f?.id === defaultOwnerFilterId
+    );
+
     const [budgetDiscussionSearchText, setBudgetDiscussionSearchText] =
         useState('');
     const [sortType, setSortType] = useState('desc');
@@ -60,6 +72,9 @@ const ProposedBudgetDiscussion = () => {
         filteredBudgetDiscussionTypeList,
         setFilteredBudgetDiscussionTypeList,
     ] = useState([]);
+    const [proposalsOwnerFilter, setProposalsOwnerFilter] =
+        useState(defaultOwnerFilter); // All proposals as default
+
     const [showCreateBDDialog, setShowCreateBDDialog] = useState(false);
     const [
         filteredBudgetDiscussionStatusList,
@@ -109,9 +124,25 @@ const ProposedBudgetDiscussion = () => {
         setFilteredBudgetDiscussionTypeList(updatedList);
     };
 
+    const toggleProposalsOwnersFilter = (e) => {
+        const propOwnerFilterId = e?.target?.value?.toString();
+        let propOwnerFilter = proposalsOwnersList?.find(
+            (f) => f?.id?.toString() === propOwnerFilterId
+        );
+
+        if (propOwnerFilter) {
+            setProposalsOwnerFilter(propOwnerFilter);
+        }
+    };
+
     const resetFilters = () => {
         setFilteredBudgetDiscussionTypeList([]);
         handleCloseFilters();
+        setShowAllActivated({
+            is_activated: false,
+            bd_type: null,
+        });
+        setProposalsOwnerFilter(defaultOwnerFilter);
     };
 
     useEffect(() => {
@@ -319,6 +350,7 @@ const ProposedBudgetDiscussion = () => {
                                             sx: {
                                                 overflow: 'visible',
                                                 mt: 1,
+                                                minWidth: '300px',
                                             },
                                         },
                                     }}
@@ -424,6 +456,95 @@ const ProposedBudgetDiscussion = () => {
                                                 )}
                                             </Box>
                                         )}
+                                        <Typography
+                                            variant='body1'
+                                            sx={{
+                                                mb: 1,
+                                            }}
+                                        >
+                                            Proposals owners
+                                        </Typography>
+                                        <Divider
+                                            sx={{
+                                                color: (theme) => ({
+                                                    borderColor:
+                                                        theme.palette.border
+                                                            .lightGray,
+                                                }),
+                                            }}
+                                        />
+
+                                        {proposalsOwnersList?.map(
+                                            (ga, index) => (
+                                                <MenuItem
+                                                    key={`${ga?.id}-${index}`}
+                                                    selected={
+                                                        proposalsOwnerFilter?.id ===
+                                                        ga?.id
+                                                    }
+                                                    id={`${ga?.id}-radio-wrapper`}
+                                                    data-testid={
+                                                        ga?.label
+                                                            ?.replace(
+                                                                /\s+/g,
+                                                                '-'
+                                                            )
+                                                            ?.toLowerCase() +
+                                                        `-radio-wrapper`
+                                                    }
+                                                    onClick={
+                                                        toggleProposalsOwnersFilter
+                                                    }
+                                                    sx={{ width: '100%' }}
+                                                >
+                                                    <FormControlLabel
+                                                        name='owner-filter'
+                                                        control={
+                                                            <Radio
+                                                                checked={
+                                                                    proposalsOwnerFilter?.id ===
+                                                                    ga?.id
+                                                                }
+                                                            />
+                                                        }
+                                                        id={`${ga?.label}-radio`}
+                                                        data-testid={
+                                                            ga?.label
+                                                                ?.replace(
+                                                                    /\s+/g,
+                                                                    '-'
+                                                                )
+                                                                ?.toLowerCase() +
+                                                            `-radio`
+                                                        }
+                                                        sx={{
+                                                            width: '100%',
+                                                            marginRight: 0,
+                                                        }}
+                                                        value={ga?.id}
+                                                        label={
+                                                            <Typography
+                                                                data-testid={`${ga?.label}-owner-filter-option`}
+                                                                color={
+                                                                    'text.black'
+                                                                }
+                                                                variant='body1'
+                                                                sx={{
+                                                                    width: '100%',
+                                                                    overflowX:
+                                                                        'hidden',
+                                                                    textOverflow:
+                                                                        'ellipsis',
+                                                                }}
+                                                            >
+                                                                {ga?.label}
+                                                            </Typography>
+                                                        }
+                                                    />
+                                                </MenuItem>
+                                            )
+                                        )}
+
                                         <MenuItem
                                             onClick={() => resetFilters()}
                                             data-testid='reset-filters'
@@ -503,6 +624,7 @@ const ProposedBudgetDiscussion = () => {
                             filteredBudgetDiscussionTypeList={
                                 filteredBudgetDiscussionTypeList
                             }
+                            proposalOwnerFilter={proposalsOwnerFilter}
                         />
                     </Box>
                 ))}


### PR DESCRIPTION
## List of changes

- Add My proposals and All proposals filter to Budget Discussion, handle reset filters to set to all proposals by default

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3353)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
