### PR TITLE
3344 allow hyperlinking to sub heading on budget form

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
+++ b/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
@@ -28,7 +28,7 @@ import {
     openInNewTab,
 } from '../../lib/utils';
 import { useEffect, useState } from 'react';
-import { getBudgetDiscussionVersions } from '../../lib/api';
+import { getBudgetDiscussionVersions, getCountryList } from '../../lib/api';
 import BudgetDiscussionInfoSegment from '../BudgetDiscussionInfoSegment';
 
 const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
@@ -38,6 +38,7 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
     const [versions, setVersions] = useState(null);
     const [selectedVersion, setSelectedVersion] = useState(null);
     const [openVersionsList, setOpenVersionsList] = useState(false);
+    const [allCountries, setAllCountries] = useState([]);
 
     const isSmallScreen = useMediaQuery((theme) =>
         theme.breakpoints.down('md')
@@ -59,8 +60,20 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
     };
 
     useEffect(() => {
+        const fetchData = async () => {
+            try {
+                if (!allCountries.length) {
+                    const countriesResponse = await getCountryList();
+                    setAllCountries(countriesResponse?.data || []);
+                }
+            } catch (error) {
+                console.error('Error fetching data:', error);
+            }
+        };
+
         if (open) {
             fetchVersions();
+            fetchData();
         }
     }, [open]);
 
@@ -406,99 +419,121 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                                         ?.proposal_public_champion
                                                                 }
                                                             /> */}
-                                                            {selectedVersion?.attributes
-                                                            ?.bd_proposal_ownership?.data
-                                                            ?.attributes?.submited_on_behalf ===
-                                                        'Company' ? (
-                                                            <Box>
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Company Name'
-                                                                    answer={
-                                                                        selectedVersion?.attributes
-                                                                            ?.bd_proposal_ownership
-                                                                            ?.data?.attributes
-                                                                            ?.company_name || ''
-                                                                    }
-                                                                    answerTestId='company-name-content'
-                                                                />
-                
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Company Domain Name'
-                                                                    answer={
-                                                                        selectedVersion?.attributes
-                                                                            ?.bd_proposal_ownership
-                                                                            ?.data?.attributes
-                                                                            ?.company_domain_name ||
-                                                                        ''
-                                                                    }
-                                                                    answerTestId='company-domain-name-content'
-                                                                />
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Country of Incorporation'
-                                                                    answer={
-                                                                        allCountries.find(
-                                                                            (country) =>
-                                                                                country.id ===
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.bd_proposal_ownership
+                                                                ?.data
+                                                                ?.attributes
+                                                                ?.submited_on_behalf ===
+                                                            'Company' ? (
+                                                                <Box>
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Company Name'
+                                                                        answer={
                                                                             selectedVersion
-                                                                                    ?.attributes
-                                                                                    .bd_proposal_ownership
-                                                                                    .data
-                                                                                    .attributes
-                                                                                    .be_country
-                                                                                    .data.id
-                                                                        )?.attributes
-                                                                            ?.country_name ||
-                                                                        'Error'
-                                                                    }
-                                                                    answerTestId='country-of-incorporation-content'
-                                                                />
-                                                            </Box>
-                                                        ) : (
-                                                            ''
-                                                        )}
-                                                        {selectedVersion?.attributes
-                                                            ?.bd_proposal_ownership?.data
-                                                            ?.attributes?.submited_on_behalf ===
-                                                        'Group' ? (
-                                                            <Box>
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Group Name'
-                                                                    answer={
-                                                                        selectedVersion?.attributes
-                                                                            ?.bd_proposal_ownership
-                                                                            ?.data?.attributes
-                                                                            ?.group_name || ''
-                                                                    }
-                                                                    answerTestId='group-name-content'
-                                                                />
-                
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Type of Group'
-                                                                    answer={
-                                                                        selectedVersion?.attributes
-                                                                            ?.bd_proposal_ownership
-                                                                            ?.data?.attributes
-                                                                            ?.type_of_group ||
-                                                                        ''
-                                                                    }
-                                                                    answerTestId='group-type-content'
-                                                                />
-                                                                <BudgetDiscussionInfoSegment
-                                                                    question='Key Information to Identify
+                                                                                ?.attributes
+                                                                                ?.bd_proposal_ownership
+                                                                                ?.data
+                                                                                ?.attributes
+                                                                                ?.company_name ||
+                                                                            ''
+                                                                        }
+                                                                        answerTestId='company-name-content'
+                                                                    />
+
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Company Domain Name'
+                                                                        answer={
+                                                                            selectedVersion
+                                                                                ?.attributes
+                                                                                ?.bd_proposal_ownership
+                                                                                ?.data
+                                                                                ?.attributes
+                                                                                ?.company_domain_name ||
+                                                                            ''
+                                                                        }
+                                                                        answerTestId='company-domain-name-content'
+                                                                    />
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Country of Incorporation'
+                                                                        answer={
+                                                                            allCountries?.find(
+                                                                                (
+                                                                                    country
+                                                                                ) =>
+                                                                                    country?.id ===
+                                                                                    selectedVersion
+                                                                                        ?.attributes
+                                                                                        ?.bd_proposal_ownership
+                                                                                        ?.data
+                                                                                        ?.attributes
+                                                                                        ?.be_country
+                                                                                        ?.data
+                                                                                        ?.id
+                                                                            )
+                                                                                ?.attributes
+                                                                                ?.country_name ||
+                                                                            'Error'
+                                                                        }
+                                                                        answerTestId='country-of-incorporation-content'
+                                                                    />
+                                                                </Box>
+                                                            ) : (
+                                                                ''
+                                                            )}
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.bd_proposal_ownership
+                                                                ?.data
+                                                                ?.attributes
+                                                                ?.submited_on_behalf ===
+                                                            'Group' ? (
+                                                                <Box>
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Group Name'
+                                                                        answer={
+                                                                            selectedVersion
+                                                                                ?.attributes
+                                                                                ?.bd_proposal_ownership
+                                                                                ?.data
+                                                                                ?.attributes
+                                                                                ?.group_name ||
+                                                                            ''
+                                                                        }
+                                                                        answerTestId='group-name-content'
+                                                                    />
+
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Type of Group'
+                                                                        answer={
+                                                                            selectedVersion
+                                                                                ?.attributes
+                                                                                ?.bd_proposal_ownership
+                                                                                ?.data
+                                                                                ?.attributes
+                                                                                ?.type_of_group ||
+                                                                            ''
+                                                                        }
+                                                                        answerTestId='group-type-content'
+                                                                    />
+                                                                    <BudgetDiscussionInfoSegment
+                                                                        question='Key Information to Identify
                                                                 Group'
-                                                                    answer={
-                                                                        selectedVersion?.attributes
-                                                                            ?.bd_proposal_ownership
-                                                                            ?.data?.attributes
-                                                                            ?.key_info_to_identify_group ||
-                                                                        ''
-                                                                    }
-                                                                    answerTestId='group-identity-information-content'
-                                                                />
-                                                            </Box>
-                                                        ) : (
-                                                            ''
-                                                        )}
+                                                                        answer={
+                                                                            selectedVersion
+                                                                                ?.attributes
+                                                                                ?.bd_proposal_ownership
+                                                                                ?.data
+                                                                                ?.attributes
+                                                                                ?.key_info_to_identify_group ||
+                                                                            ''
+                                                                        }
+                                                                        answerTestId='group-identity-information-content'
+                                                                    />
+                                                                </Box>
+                                                            ) : (
+                                                                ''
+                                                            )}
 
                                                             <BudgetDiscussionInfoSegment
                                                                 question={
@@ -580,13 +615,29 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                                 }
                                                                 answerTestId='product-roadmap'
                                                             />
-                                                            {   selectedVersion?.attributes?.bd_psapb?.data?.attributes?.explain_proposal_roadmap ?
-                                                            <BudgetDiscussionInfoSegment
-                                                                question='Please explain how your proposal supports the Product Roadmap.'
-                                                                answer={selectedVersion?.attributes?.bd_psapb?.data?.attributes?.explain_proposal_roadmap || ''}
-                                                                answerTestId={'explain-roadmap-content'}
-                                                            />
-                                                            :''}
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.bd_psapb?.data
+                                                                ?.attributes
+                                                                ?.explain_proposal_roadmap ? (
+                                                                <BudgetDiscussionInfoSegment
+                                                                    question='Please explain how your proposal supports the Product Roadmap.'
+                                                                    answer={
+                                                                        selectedVersion
+                                                                            ?.attributes
+                                                                            ?.bd_psapb
+                                                                            ?.data
+                                                                            ?.attributes
+                                                                            ?.explain_proposal_roadmap ||
+                                                                        ''
+                                                                    }
+                                                                    answerTestId={
+                                                                        'explain-roadmap-content'
+                                                                    }
+                                                                />
+                                                            ) : (
+                                                                ''
+                                                            )}
                                                             <BudgetDiscussionInfoSegment
                                                                 question={
                                                                     'Does your proposal align to any of the budget categories?'
@@ -716,9 +767,11 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                                 question='How will this proposal be maintained and
                                                                 supported after initial development?'
                                                                 answer={
-                                                                    selectedVersion?.attributes
+                                                                    selectedVersion
+                                                                        ?.attributes
                                                                         ?.bd_proposal_detail
-                                                                        ?.data?.attributes
+                                                                        ?.data
+                                                                        ?.attributes
                                                                         ?.maintain_and_support ||
                                                                     ''
                                                                 }

--- a/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
+++ b/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
@@ -5,7 +5,8 @@ import CommentReportPopup from '../../CommentReportPopup';
 import { isCommentRestricted } from '../../../lib/helpers';
 import { formatDateWithOffset } from '../../../lib/utils';
 import UsernameSection from '../UsernameSection';
-const Subcomponent = ({ comment }) => {
+import MarkdownTypography from '../../../lib/markdownRenderer';
+const Subcomponent = ({ comment, handleMarkdownLinkClick }) => {
     const { fetchDRepVotingPowerList } = useAppContext();
     const [drepData, setDrepData] = useState({});
     const [showReportCommentPopup, setShowReportCommentPopup] = useState(false);
@@ -135,7 +136,37 @@ const Subcomponent = ({ comment }) => {
                         </Box>
                     </Box>
                 </Box>
-                <Typography
+                {isCommentRestricted(comment) === true ? (
+                    <Typography
+                        variant='body2'
+                        sx={{
+                            maxWidth: '100%',
+                            wordWrap: 'break-word',
+                            whiteSpace: 'pre-line',
+                        }}
+                        data-testid={`comment-${comment?.id}-content`}
+                    >
+                        Restricted comment due to reports
+                    </Typography>
+                ) : null}
+
+                {isCommentRestricted(comment) === false ? (
+                    <MarkdownTypography
+                        content={
+                            isExpanded
+                                ? comment?.attributes?.comment_text
+                                : sliceString(
+                                      comment?.attributes?.comment_text
+                                  ) || ''
+                        }
+                        testId={`reply-${comment?.id}-content`}
+                        onLinkClick={(href, e) =>
+                            handleMarkdownLinkClick &&
+                            handleMarkdownLinkClick(href, e)
+                        }
+                    />
+                ) : null}
+                {/* <Typography
                     variant='body2'
                     data-testid={`reply-${comment?.id}-content`}
                     sx={{
@@ -150,7 +181,7 @@ const Subcomponent = ({ comment }) => {
                             : sliceString(comment?.attributes?.comment_text) ||
                               ''
                         : 'Restricted comment due to reports'}
-                </Typography>
+                </Typography> */}
 
                 {comment?.attributes?.comment_text?.length > maxLength && (
                     <Box mt={2}>

--- a/pdf-ui/src/lib/markdownRenderer.js
+++ b/pdf-ui/src/lib/markdownRenderer.js
@@ -25,6 +25,7 @@ const markdownTags = [
     'del',
     'span',
     'hr',
+    'a',
 ];
 
 // Map Markdown tags to MUI `Typography` variants
@@ -51,23 +52,23 @@ const fontWeights = {
 
 const symbolReplacements = (text) =>
     text
-        .replace(/\(c\)/gi, '©')
-        .replace(/\(r\)/gi, '®')
-        .replace(/\(tm\)/gi, '™')
-        .replace(/\(p\)/gi, '℗')
-        .replace(/\+\/-/g, '±')
-        .replace(/\.\.+/g, '…') // change .. with ...
-        .replace(/([?!])…/g, '$1..') // Change?... with ?..
-        .replace(/([?!]){4,}/g, '$1$1$1') // Search multiply ? or !
-        .replace(/,{2,}/g, ',') // Change multiple commas with one
-        .replace(/(^|\s)--(?=\s|$)/gm, '$1\u2013') // Change -- with en-dash
-        .replace(/(^|[^-\s])--(?=[^-\s]|$)/gm, '$1\u2013'); // Change -- with en-dash in context
+        ?.replace(/\(c\)/gi, '©')
+        ?.replace(/\(r\)/gi, '®')
+        ?.replace(/\(tm\)/gi, '™')
+        ?.replace(/\(p\)/gi, '℗')
+        ?.replace(/\+\/-/g, '±')
+        ?.replace(/\.\.+/g, '…') // change .. with ...
+        ?.replace(/([?!])…/g, '$1..') // Change?... with ?..
+        ?.replace(/([?!]){4,}/g, '$1$1$1') // Search multiply ? or !
+        ?.replace(/,{2,}/g, ',') // Change multiple commas with one
+        ?.replace(/(^|\s)--(?=\s|$)/gm, '$1\u2013') // Change -- with en-dash
+        ?.replace(/(^|[^-\s])--(?=[^-\s]|$)/gm, '$1\u2013'); // Change -- with en-dash in context
 // .replace(/(^|[^-])---(?=[^-]|$)/gm, '$1\u2014') // Change --- with em-dash
 
-const MarkdownTypography = ({ content, testId }) => {
+const MarkdownTypography = ({ content, testId, onLinkClick }) => {
     const theme = useTheme();
     const typographyComponents = markdownTags.reduce((acc, tag) => {
-        acc[tag] = ({ children }) => {
+        acc[tag] = ({ href, children }) => {
             // Render hr tag without any modification then this
             if (tag === 'hr') {
                 return <hr style={{ marginTop: 0, marginBottom: '1rem' }} />;
@@ -130,6 +131,21 @@ const MarkdownTypography = ({ content, testId }) => {
                 );
             }
 
+            if (tag === 'a') {
+                return (
+                    <a
+                        href={href}
+                        onClick={(e) => {
+                            if (onLinkClick) {
+                                onLinkClick(href, e);
+                            }
+                        }}
+                    >
+                        {children}
+                    </a>
+                );
+            }
+
             return (
                 <Typography
                     variant={typographyVariants[tag] || 'body1'}
@@ -174,7 +190,7 @@ const MarkdownTypography = ({ content, testId }) => {
         let preservedTextIndex = 0;
 
         // Save text with intends and its placeholders
-        text = text.replace(indentedCodeRegex, (match) => {
+        text = text?.replace(indentedCodeRegex, (match) => {
             preservedIndentedCode[preservedTextIndex] = match;
             preservedTextIndex++;
             return `<!--indentedCode${preservedTextIndex - 1}-->`;
@@ -182,7 +198,7 @@ const MarkdownTypography = ({ content, testId }) => {
 
         const preserveCodeBlocksRegex = /```(.*?)```/gs;
         let preservedCodeBlocks = [];
-        text = text.replace(preserveCodeBlocksRegex, (match, codeContent) => {
+        text = text?.replace(preserveCodeBlocksRegex, (match, codeContent) => {
             preservedCodeBlocks.push(codeContent);
             return `<!--codeBlock${preservedCodeBlocks.length - 1}-->`;
         });
@@ -196,30 +212,30 @@ const MarkdownTypography = ({ content, testId }) => {
         // });
 
         preservedCodeBlocks.forEach((codeBlock, index) => {
-            text = text.replace(
+            text = text?.replace(
                 `<!--codeBlock${index}-->`,
                 `\`\`\`${codeBlock}\`\`\``
             );
         });
 
         // Handle strikethrough text
-        text = text.replace(/~~(.*?)~~/g, '<del>$1</del>'); // This will replace ~~text~~ with <del>text</del>
+        text = text?.replace(/~~(.*?)~~/g, '<del>$1</del>'); // This will replace ~~text~~ with <del>text</del>
 
         // Recognition of marked text (==text==) and change with <mark> tags
-        text = text.replace(/==(.*?)==/g, '<mark>$1</mark>'); // This will replace ==text== with <mark>text</mark>
+        text = text?.replace(/==(.*?)==/g, '<mark>$1</mark>'); // This will replace ==text== with <mark>text</mark>
 
         // Recognition of inserted text (++text++) and change with <ins> tags
-        text = text.replace(/\+\+(.*?)\+\+/g, '<ins>$1</ins>'); // This will replace ++text++ with <ins>text</ins>
+        text = text?.replace(/\+\+(.*?)\+\+/g, '<ins>$1</ins>'); // This will replace ++text++ with <ins>text</ins>
 
         // Recognition superscript (19^th^) and change with <sup> tags
-        text = text.replace(/\^([^~\^]+)\^/g, '<sup>$1</sup>'); // This will replace 19^th^ with <sup>th</sup>
+        text = text?.replace(/\^([^~\^]+)\^/g, '<sup>$1</sup>'); // This will replace 19^th^ with <sup>th</sup>
 
         // Recognition subscript (H~2~O) and change with <sub> tags
-        text = text.replace(/~([^~]+)~/g, '<sub>$1</sub>'); // This will replace H~2~O with <sub>2</sub>O
+        text = text?.replace(/~([^~]+)~/g, '<sub>$1</sub>'); // This will replace H~2~O with <sub>2</sub>O
 
         // Return code and comments back with their values
         preservedIndentedCode.forEach((code, index) => {
-            text = text.replace(`<!--indentedCode${index}-->`, code);
+            text = text?.replace(`<!--indentedCode${index}-->`, code);
         });
 
         // // Table regex

--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -27,7 +27,7 @@ import {
     alpha,
 } from '@mui/material';
 import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
     CommentCard,
     BudgetDiscussionPoll,
@@ -78,6 +78,23 @@ const SingleBudgetDiscussion = ({ id }) => {
     const [showCreateBDDialog, setShowCreateBDDialog] = useState(false);
     const [refetchProposal, setRefetchProposal] = useState(false);
     const [allCountries, setAllCountries] = useState([]);
+    const [hoveredSection, setHoveredSection] = useState(null);
+
+    function copyToClipboard(value) {
+        navigator.clipboard.writeText(value);
+    }
+
+    const handleSectionEnter = (sectionId) => {
+        setHoveredSection(sectionId);
+    };
+
+    const handleSectionLeave = () => {
+        setHoveredSection(null);
+    };
+
+    const handleToggleSection = (sectionId) => {
+        setHoveredSection(hoveredSection === sectionId ? null : sectionId);
+    };
 
     // Read More / Show Less logic
     const [showFullText, setShowFullText] = useState(false);
@@ -298,6 +315,33 @@ const SingleBudgetDiscussion = ({ id }) => {
         if (!proposal?.id) return;
         fetchActivePoll();
     }, [proposal]);
+
+    const location = useLocation();
+
+    useEffect(() => {
+        const sectionId = location?.hash;
+        if (sectionId) {
+            setShowFullText(true);
+            setTimeout(() => {
+                const section = document?.getElementById(sectionId);
+
+                if (section) {
+                    const rect = section?.getBoundingClientRect();
+                    const offsetTop = rect.top + window.scrollY - 20;
+
+                    const header = document?.querySelector('header');
+                    const headerHeight = header ? header?.offsetHeight : 80;
+
+                    window.scrollTo({
+                        top: offsetTop - headerHeight,
+                        behavior: 'smooth',
+                    });
+                } else {
+                    setShowFullText(false);
+                }
+            }, 200);
+        }
+    }, [location?.hash]);
 
     return !proposal ? null : proposal?.attributes?.content?.attributes
           ?.is_draft ? null : (
@@ -772,9 +816,44 @@ const SingleBudgetDiscussion = ({ id }) => {
                                             variant='h5'
                                             sx={{
                                                 mb: 2,
+                                                position: 'relative',
                                             }}
+                                            onClick={() =>
+                                                handleToggleSection(
+                                                    'problem-ownership'
+                                                )
+                                            }
+                                            onMouseEnter={() =>
+                                                handleSectionEnter(
+                                                    'problem-ownership'
+                                                )
+                                            }
+                                            onMouseLeave={handleSectionLeave}
+                                            id='#problem-ownership'
                                         >
                                             Proposal Ownership
+                                            {hoveredSection ===
+                                            'problem-ownership' ? (
+                                                <IconButton
+                                                    sx={{
+                                                        ml: 1,
+                                                        position: 'absolute',
+                                                        top: '50%',
+                                                        transform:
+                                                            'translateY(-50%)',
+                                                    }}
+                                                    onClick={() =>
+                                                        copyToClipboard(
+                                                            `${proposalLink}${proposal?.attributes?.master_id}#problem-ownership`
+                                                        )
+                                                    }
+                                                >
+                                                    <IconLink
+                                                        width={20}
+                                                        height={20}
+                                                    />
+                                                </IconButton>
+                                            ) : null}
                                         </Typography>
 
                                         {/* <BudgetDiscussionInfoSegment
@@ -905,10 +984,45 @@ const SingleBudgetDiscussion = ({ id }) => {
                                             variant='h5'
                                             sx={{
                                                 mb: 2,
+                                                position: 'relative',
                                             }}
+                                            onClick={() =>
+                                                handleToggleSection(
+                                                    'problem-statement'
+                                                )
+                                            }
+                                            onMouseEnter={() =>
+                                                handleSectionEnter(
+                                                    'problem-statement'
+                                                )
+                                            }
+                                            onMouseLeave={handleSectionLeave}
+                                            id='#problem-statement'
                                         >
                                             Problem Statements and Proposal
                                             Benefits
+                                            {hoveredSection ===
+                                            'problem-statement' ? (
+                                                <IconButton
+                                                    sx={{
+                                                        ml: 1,
+                                                        position: 'absolute',
+                                                        top: '50%',
+                                                        transform:
+                                                            'translateY(-50%)',
+                                                    }}
+                                                    onClick={() =>
+                                                        copyToClipboard(
+                                                            `${proposalLink}${proposal?.attributes?.master_id}#problem-statement`
+                                                        )
+                                                    }
+                                                >
+                                                    <IconLink
+                                                        width={20}
+                                                        height={20}
+                                                    />
+                                                </IconButton>
+                                            ) : null}
                                         </Typography>
 
                                         <BudgetDiscussionInfoSegment
@@ -945,12 +1059,25 @@ const SingleBudgetDiscussion = ({ id }) => {
                                             show={showFullText}
                                             answerTestId='product-roadmap'
                                         />
-                                        {   proposal?.attributes?.bd_psapb?.data?.attributes?.explain_proposal_roadmap?                                            <BudgetDiscussionInfoSegment
+                                        {proposal?.attributes?.bd_psapb?.data
+                                            ?.attributes
+                                            ?.explain_proposal_roadmap ? (
+                                            <BudgetDiscussionInfoSegment
                                                 question='Please explain how your proposal supports the Product Roadmap.'
-                                                answer={proposal?.attributes?.bd_psapb?.data?.attributes?.explain_proposal_roadmap || ''}
-                                                answerTestId={'explain-roadmap-content'}
+                                                answer={
+                                                    proposal?.attributes
+                                                        ?.bd_psapb?.data
+                                                        ?.attributes
+                                                        ?.explain_proposal_roadmap ||
+                                                    ''
+                                                }
+                                                answerTestId={
+                                                    'explain-roadmap-content'
+                                                }
                                             />
-                                        :''}
+                                        ) : (
+                                            ''
+                                        )}
                                         <BudgetDiscussionInfoSegment
                                             question={
                                                 'Does your proposal align to any of the budget categories?'
@@ -1003,9 +1130,47 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 variant='h5'
                                                 sx={{
                                                     mb: 2,
+                                                    position: 'relative',
                                                 }}
+                                                onClick={() =>
+                                                    handleToggleSection(
+                                                        'proposal-details'
+                                                    )
+                                                }
+                                                onMouseEnter={() =>
+                                                    handleSectionEnter(
+                                                        'proposal-details'
+                                                    )
+                                                }
+                                                onMouseLeave={
+                                                    handleSectionLeave
+                                                }
+                                                id='#proposal-details'
                                             >
                                                 Proposal Details
+                                                {hoveredSection ===
+                                                'proposal-details' ? (
+                                                    <IconButton
+                                                        sx={{
+                                                            ml: 1,
+                                                            position:
+                                                                'absolute',
+                                                            top: '50%',
+                                                            transform:
+                                                                'translateY(-50%)',
+                                                        }}
+                                                        onClick={() =>
+                                                            copyToClipboard(
+                                                                `${proposalLink}${proposal?.attributes?.master_id}#proposal-details`
+                                                            )
+                                                        }
+                                                    >
+                                                        <IconLink
+                                                            width={20}
+                                                            height={20}
+                                                        />
+                                                    </IconButton>
+                                                ) : null}
                                             </Typography>
 
                                             <BudgetDiscussionInfoSegment
@@ -1125,9 +1290,47 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 variant='h5'
                                                 sx={{
                                                     mb: 2,
+                                                    position: 'relative',
                                                 }}
+                                                onClick={() =>
+                                                    handleToggleSection(
+                                                        'costing'
+                                                    )
+                                                }
+                                                onMouseEnter={() =>
+                                                    handleSectionEnter(
+                                                        'costing'
+                                                    )
+                                                }
+                                                onMouseLeave={
+                                                    handleSectionLeave
+                                                }
+                                                id='#costing'
                                             >
                                                 Costing
+                                                {hoveredSection ===
+                                                'costing' ? (
+                                                    <IconButton
+                                                        sx={{
+                                                            ml: 1,
+                                                            position:
+                                                                'absolute',
+                                                            top: '50%',
+                                                            transform:
+                                                                'translateY(-50%)',
+                                                        }}
+                                                        onClick={() =>
+                                                            copyToClipboard(
+                                                                `${proposalLink}${proposal?.attributes?.master_id}#costing`
+                                                            )
+                                                        }
+                                                    >
+                                                        <IconLink
+                                                            width={20}
+                                                            height={20}
+                                                        />
+                                                    </IconButton>
+                                                ) : null}
                                             </Typography>
 
                                             <BudgetDiscussionInfoSegment
@@ -1204,9 +1407,47 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 variant='h5'
                                                 sx={{
                                                     mb: 2,
+                                                    position: 'relative',
                                                 }}
+                                                onClick={() =>
+                                                    handleToggleSection(
+                                                        'further-information'
+                                                    )
+                                                }
+                                                onMouseEnter={() =>
+                                                    handleSectionEnter(
+                                                        'further-information'
+                                                    )
+                                                }
+                                                onMouseLeave={
+                                                    handleSectionLeave
+                                                }
+                                                id='#further-information'
                                             >
                                                 Further information
+                                                {hoveredSection ===
+                                                'further-information' ? (
+                                                    <IconButton
+                                                        sx={{
+                                                            ml: 1,
+                                                            position:
+                                                                'absolute',
+                                                            top: '50%',
+                                                            transform:
+                                                                'translateY(-50%)',
+                                                        }}
+                                                        onClick={() =>
+                                                            copyToClipboard(
+                                                                `${proposalLink}${proposal?.attributes?.master_id}#further-information`
+                                                            )
+                                                        }
+                                                    >
+                                                        <IconLink
+                                                            width={20}
+                                                            height={20}
+                                                        />
+                                                    </IconButton>
+                                                ) : null}
                                             </Typography>
                                             {proposal?.attributes
                                                 ?.bd_further_information?.data
@@ -1290,9 +1531,47 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 variant='h5'
                                                 sx={{
                                                     mb: 2,
+                                                    position: 'relative',
                                                 }}
+                                                onClick={() =>
+                                                    handleToggleSection(
+                                                        'administrating-and-auditing'
+                                                    )
+                                                }
+                                                onMouseEnter={() =>
+                                                    handleSectionEnter(
+                                                        'administrating-and-auditing'
+                                                    )
+                                                }
+                                                onMouseLeave={
+                                                    handleSectionLeave
+                                                }
+                                                id='#administrating-and-auditing'
                                             >
                                                 Administration and Auditing
+                                                {hoveredSection ===
+                                                'administrating-and-auditing' ? (
+                                                    <IconButton
+                                                        sx={{
+                                                            ml: 1,
+                                                            position:
+                                                                'absolute',
+                                                            top: '50%',
+                                                            transform:
+                                                                'translateY(-50%)',
+                                                        }}
+                                                        onClick={() =>
+                                                            copyToClipboard(
+                                                                `${proposalLink}${proposal?.attributes?.master_id}#administrating-and-auditing`
+                                                            )
+                                                        }
+                                                    >
+                                                        <IconLink
+                                                            width={20}
+                                                            height={20}
+                                                        />
+                                                    </IconButton>
+                                                ) : null}
                                             </Typography>
 
                                             <BudgetDiscussionInfoSegment


### PR DESCRIPTION
## List of changes

- Add hyperlinking to specific section in proposal detail in budget discussion

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3344)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
