### PR TITLE
fix: handle clone fields to be floats

### DIFF
--- a/backend/src/api/bd-costing/content-types/bd-costing/schema.json
+++ b/backend/src/api/bd-costing/content-types/bd-costing/schema.json
@@ -12,34 +12,34 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "cost_breakdown": {
-      "type": "text"
-    },
-    "preferred_currency": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::bd-currency-list.bd-currency-list"
-    },
-    "ada_amount": {
-      "type": "string"
-    },
-    "amount_in_preferred_currency": {
-      "type": "string"
-    },
-    "usd_to_ada_conversion_rate": {
-      "type": "string"
-    },
-    "ada_amount_clone": {
-      "type": "decimal",
-      "default": 0
-    },
-    "amount_in_preferred_currency_clone": {
-      "type": "decimal",
-      "default": 0
-    },
-    "usd_to_ada_conversion_rate_clone": {
-      "type": "decimal",
-      "default": 0
-    }
+		"cost_breakdown": {
+			"type": "text"
+		},
+		"preferred_currency": {
+			"type": "relation",
+			"relation": "oneToOne",
+			"target": "api::bd-currency-list.bd-currency-list"
+		},
+		"ada_amount": {
+			"type": "string"
+		},
+		"amount_in_preferred_currency": {
+			"type": "string"
+		},
+		"usd_to_ada_conversion_rate": {
+			"type": "string"
+		},
+		"ada_amount_clone": {
+			"type": "float",
+			"default": 0
+		},
+		"amount_in_preferred_currency_clone": {
+			"type": "float",
+			"default": 0
+		},
+		"usd_to_ada_conversion_rate_clone": {
+			"type": "float",
+			"default": 0
+		}
   }
 }

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -13,7 +13,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-04-23T09:24:01.563Z"
+    "x-generation-date": "2025-04-24T09:40:28.888Z"
   },
   "x-strapi-config": {
     "plugins": [],


### PR DESCRIPTION
## List of changes

- Fix for clone fields to be floats

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
