### PR TITLE
Fix for checking value in guardrails script url and hash

### DIFF
--- a/pdf-ui/src/components/CreationGoveranceAction/Step2.jsx
+++ b/pdf-ui/src/components/CreationGoveranceAction/Step2.jsx
@@ -143,7 +143,17 @@ const Step2 = ({
             {
                 setIsDraftDisabled(false)
             }
-        
+            if(proposalData?.proposal_constitution_content?.prop_have_guardrails_script)
+                {
+                    if(!proposalData.proposal_constitution_content.prop_guardrails_script_url && !proposalData.proposal_constitution_content.prop_guardrails_script_hash)
+                        setIsDraftDisabled(false)
+                    else
+                        setIsDraftDisabled(true)
+                }
+                else 
+                {
+                    setIsDraftDisabled(true)
+                }
 
     },[proposalData])
     return (


### PR DESCRIPTION
## List of changes

- Fix for checking value in guardrails script url and hash
## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
