### PR TITLE
feat(#2243) Insufficient balance check should be earlier in GA submis…

### DIFF
--- a/pdf-ui/src/components/ThemeProviderWrapper/index.jsx
+++ b/pdf-ui/src/components/ThemeProviderWrapper/index.jsx
@@ -102,6 +102,49 @@ let theme = createTheme({
                 },
             },
         },
+        MuiDialog: {
+            styleOverrides: {
+              paper: {
+                borderRadius: '28px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+              },
+            },
+          },
+          MuiDialogTitle: {
+            styleOverrides: {
+              root: {
+                padding: '16px',
+                backgroundColor: '#f8f9fa',
+                borderBottom: '1px solid #e9ecef',
+                fontWeight: 'bold',
+                fontSize: '18px',
+                color: '#212529',
+              },
+            },
+          },
+          MuiDialogContent: {
+            styleOverrides: {
+              root: {
+                padding: '20px 16px',
+                selfstretch: 'stretch',
+                fontFamily: 'Poppins',
+                fontSize: '16px',
+                tracking: '0.5px',
+                leading: '150%',
+                lineHeight: '1.5',
+                color: '#506288',
+              },
+            },
+          },
+          MuiDialogActions: {
+            styleOverrides: {
+              root: {
+                padding: '12px 16px',
+                justifyContent: 'flex-end',
+                borderTop: '1px solid #e9ecef',
+              },
+            },
+          },
     },
     typography: {
         fontFamily: [

--- a/pdf-ui/src/pages/ProposedGovernanceActions/SingleGovernanceAction/index.jsx
+++ b/pdf-ui/src/pages/ProposedGovernanceActions/SingleGovernanceAction/index.jsx
@@ -10,6 +10,7 @@ import {
     IconReply,
     IconShare,
     IconSort,
+    IconX,
     IconThumbDown,
     IconThumbUp,
     IconTrash,
@@ -31,6 +32,10 @@ import {
     Tooltip,
     Typography,
     alpha,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
 } from '@mui/material';
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -54,7 +59,7 @@ import {
     createPoll,
     getPolls,
 } from '../../../lib/api';
-import { formatIsoDate, openInNewTab } from '../../../lib/utils';
+import { correctVoteAdaFormat, formatIsoDate, openInNewTab } from '../../../lib/utils';
 import ProposalOwnModal from '../../../components/ProposalOwnModal';
 import ReactMarkdown from 'react-markdown';
 import { loginUserToApp } from '../../../lib/helpers';
@@ -94,6 +99,7 @@ const SingleGovernanceAction = ({ id }) => {
     const [ownProposalModal, setOwnProposalModal] = useState(false);
     const [unactivePollList, setUnactivePollList] = useState([]);
     const [activePoll, setActivePoll] = useState(null);
+    const [openAlertDialog, setOpenAlertDialog] = useState(false);
 
     const targetRef = useRef();
     const menuRef = useRef();
@@ -193,6 +199,9 @@ const SingleGovernanceAction = ({ id }) => {
         } finally {
             setLoading(false);
         }
+    };
+    const handleAlertDialogClose = () => {
+        setOpenAlertDialog(false);
     };
 
     const fetchProposal = async (id) => {
@@ -617,10 +626,17 @@ const SingleGovernanceAction = ({ id }) => {
                                                                     setOpenUsernameModal:
                                                                         setOpenUsernameModal,
                                                                     callBackFn:
-                                                                        () =>
-                                                                            setOpenGASubmissionDialog(
-                                                                                true
-                                                                            ),
+                                                                        () =>{
+                                                                            let bal = (walletAPI?.voter?.votingPower || 0);
+                                                                            if( bal/1000000 >= 100000.18)
+                                                                            {
+                                                                                setOpenGASubmissionDialog(true)
+                                                                            }
+                                                                            else
+                                                                            {
+                                                                                setOpenAlertDialog(true)
+                                                                            }
+                                                                        },
                                                                     clearStates:
                                                                         clearStates,
                                                                     addErrorAlert:
@@ -2119,7 +2135,33 @@ const SingleGovernanceAction = ({ id }) => {
                     </Box>
                 )}
             </Typography>
+            <Dialog
+                open={openAlertDialog}
+                onClose={handleAlertDialogClose}
+                >
+                <DialogContent>
+                    <Box sx={{display: 'flex',  alignItems: 'center', justifyContent: 'between', width: '100%', marginBottom:'16px'}}>
+                        <Typography variant='h5' fontWeight={600} color='text.black' width={'100%'}>
+                        Insufficient wallet balance
+                        </Typography>
+                        <IconButton   onClick={handleAlertDialogClose}>
+                            <IconX/>
+                        </IconButton>
+                    </Box>
+                <DialogContentText id="alert-dialog-description">
+                
+                    Insufficient wallet balance to submit a Governance Action. 
+                    To submit a Governance Action on-chain, you require a wallet balance of ₳100,000 (refundable deposit) plus a transaction fee of ₳0.18.
+                </DialogContentText>
+                </DialogContent>
+                <DialogActions fullWidth>
+                    <Button onClick={handleAlertDialogClose}  variant='contained' fullWidth autoFocus>
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </>
+        
     );
 };
 


### PR DESCRIPTION
## List of changes

- Add Info about insufficient balance when submit button is clicked

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2243)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
