### PR TITLE
fix: Missing Test IDs for PDF components(#2988)

### DIFF
--- a/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
+++ b/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
@@ -50,7 +50,7 @@ const Subcomponent = ({ comment, handleMarkdownLinkClick }) => {
             sx={{
                 position: 'relative',
             }}
-            data-testid={`subcomment-${comment?.id}-content`}
+            // data-testid={`subcomment-${comment?.id}-content`}
         >
             <Box
                 sx={{
@@ -159,7 +159,8 @@ const Subcomponent = ({ comment, handleMarkdownLinkClick }) => {
                                       comment?.attributes?.comment_text
                                   ) || ''
                         }
-                        testId={`reply-${comment?.id}-content`}
+                        // testId={`reply-${comment?.id}-content`}
+                        data-testid={`subcomment-${comment?.id}-content`}
                         onLinkClick={(href, e) =>
                             handleMarkdownLinkClick &&
                             handleMarkdownLinkClick(href, e)


### PR DESCRIPTION
## List of changes


- Fix Missing Test IDs for PDF components(#2988)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2988)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
