### PR TITLE
fix: Bug: "Other" Contracting Method Details Not Displayed in Review …

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionReview/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionReview/index.jsx
@@ -409,16 +409,22 @@ const BudgetDiscussionReview = ({
                                         answerTestId={'roadmap-content'}
                                     />
                                     {currentBudgetDiscussionData?.bd_psapb
-                                            ?.explain_proposal_roadmap?
-                                    <InfoSection
-                                        question='Please explain how your proposal supports the Product Roadmap.'
-                                        answer={
-                                            currentBudgetDiscussionData?.bd_psapb
-                                            ?.explain_proposal_roadmap || ''
-                                        }
-                                        answerTestId={'explain-roadmap-content'}
-                                    />
-                                    :''}
+                                        ?.explain_proposal_roadmap ? (
+                                        <InfoSection
+                                            question='Please explain how your proposal supports the Product Roadmap.'
+                                            answer={
+                                                currentBudgetDiscussionData
+                                                    ?.bd_psapb
+                                                    ?.explain_proposal_roadmap ||
+                                                ''
+                                            }
+                                            answerTestId={
+                                                'explain-roadmap-content'
+                                            }
+                                        />
+                                    ) : (
+                                        ''
+                                    )}
                                     <InfoSection
                                         question='Does your proposal align to any of the
                                         budget categories?'
@@ -581,6 +587,21 @@ const BudgetDiscussionReview = ({
                                             'contracting-type-name-content'
                                         }
                                     />
+                                    {currentBudgetDiscussionData
+                                        ?.bd_proposal_detail
+                                        ?.contract_type_name === 4 && (
+                                        <InfoSection
+                                            question='Please describe what you have in mind.'
+                                            answer={
+                                                currentBudgetDiscussionData
+                                                    ?.bd_proposal_detail
+                                                    ?.other_contract_type || ''
+                                            }
+                                            answerTestId={
+                                                'other-contract-description'
+                                            }
+                                        />
+                                    )}
                                 </Box>
                                 <Box sx={{ align: 'left' }}>
                                     <Typography

--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -79,6 +79,7 @@ const SingleBudgetDiscussion = ({ id }) => {
 
     const theme = useTheme();
     const [proposal, setProposal] = useState(null);
+    console.log('🚀 ~ SingleBudgetDiscussion ~ proposal:', proposal);
     const [mounted, setMounted] = useState(false);
     const [commentsList, setCommentsList] = useState([]);
     const [newCommentText, setNewCommentText] = useState('');
@@ -1296,6 +1297,21 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                 }
                                                 answerTestId={`proposal-contracting`}
                                             />
+                                            {proposal?.attributes
+                                                ?.bd_proposal_detail?.data
+                                                ?.attributes?.contract_type_name
+                                                ?.data?.id === 4 && (
+                                                <BudgetDiscussionInfoSegment
+                                                    question='Please describe what you have in mind.'
+                                                    answer={
+                                                        proposal?.attributes
+                                                            ?.bd_proposal_detail
+                                                            ?.data?.attributes
+                                                            ?.other_contract_type
+                                                    }
+                                                    answerTestId={`project-experience`}
+                                                />
+                                            )}
                                         </Box>
                                     )}
 


### PR DESCRIPTION
## List of changes

- Fix "Other" Contracting Method Details Not Displayed in Review

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3553)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
