### PR TITLE
fix: check for name instead of id for other

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionReview/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionParts/BudgetDiscussionReview/index.jsx
@@ -588,8 +588,9 @@ const BudgetDiscussionReview = ({
                                         }
                                     />
                                     {currentBudgetDiscussionData
-                                        ?.bd_proposal_detail
-                                        ?.contract_type_name === 4 && (
+                                        ?.bd_proposal_detail?.contract_type_name
+                                        .attributes?.contract_type_name ===
+                                        'Other' && (
                                         <InfoSection
                                             question='Please describe what you have in mind.'
                                             answer={

--- a/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
+++ b/pdf-ui/src/components/CommentCard/Subcomponent/index.jsx
@@ -159,8 +159,7 @@ const Subcomponent = ({ comment, handleMarkdownLinkClick }) => {
                                       comment?.attributes?.comment_text
                                   ) || ''
                         }
-                        // testId={`reply-${comment?.id}-content`}
-                        data-testid={`subcomment-${comment?.id}-content`}
+                        testId={`subcomment-${comment?.id}-content`}
                         onLinkClick={(href, e) =>
                             handleMarkdownLinkClick &&
                             handleMarkdownLinkClick(href, e)

--- a/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
+++ b/pdf-ui/src/pages/BudgetDiscussion/SingleBudgetDiscussion/index.jsx
@@ -79,7 +79,6 @@ const SingleBudgetDiscussion = ({ id }) => {
 
     const theme = useTheme();
     const [proposal, setProposal] = useState(null);
-    console.log('🚀 ~ SingleBudgetDiscussion ~ proposal:', proposal);
     const [mounted, setMounted] = useState(false);
     const [commentsList, setCommentsList] = useState([]);
     const [newCommentText, setNewCommentText] = useState('');
@@ -1300,7 +1299,9 @@ const SingleBudgetDiscussion = ({ id }) => {
                                             {proposal?.attributes
                                                 ?.bd_proposal_detail?.data
                                                 ?.attributes?.contract_type_name
-                                                ?.data?.id === 4 && (
+                                                ?.data?.attributes
+                                                ?.contract_type_name ===
+                                                'Other' && (
                                                 <BudgetDiscussionInfoSegment
                                                     question='Please describe what you have in mind.'
                                                     answer={
@@ -1309,7 +1310,7 @@ const SingleBudgetDiscussion = ({ id }) => {
                                                             ?.data?.attributes
                                                             ?.other_contract_type
                                                     }
-                                                    answerTestId={`project-experience`}
+                                                    answerTestId={`other-contract-description`}
                                                 />
                                             )}
                                         </Box>


### PR DESCRIPTION
## List of changes

- Change Check for name instead of id for other in SingleBudgetDiscussion and BudgetDiscussionReview, data-testId to testId / Remove Console log in SingleBudgetDiscussion

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
