### PR TITLE
fix/ Username Modal Incorrectly Pops Up on Wallet Disconnect State in…

### DIFF
--- a/pdf-ui/src/pages/ProposedGovernanceActions/index.jsx
+++ b/pdf-ui/src/pages/ProposedGovernanceActions/index.jsx
@@ -146,7 +146,7 @@ const ProposedGovernanceActions = () => {
         if (location.pathname.includes('propose')) {
             if (user?.user?.govtool_username) {
                 setShowCreateGADialog(true);
-            } else {
+            } else if (user) {
                 setOpenUsernameModal({ open: true, callBackFn: () => {} });
             }
         }


### PR DESCRIPTION
## List of changes

-Fix Username Modal Incorrectly Pops Up on Wallet Disconnect State in /proposal-discussion/propose 

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/#3187)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
