### PR TITLE
Version change to 28

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+
+## [v0.7.0-beta-28](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-28) 2025-05-15
+
+### Fixed
+-   fix: [Bug: "Other" Contracting Method Details Not Displayed in Review](https://github.com/IntersectMBO/govtool/issues/3553)
+
 ## [v0.7.0-beta-27](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-27) 2025-05-14
 
 -   feat: [Disable interactions on budget proposals](https://github.com/IntersectMBO/govtool/issues/3614)

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@intersect.mbo/pdf-ui",
-    "version": "0.7.0-beta-27",
+    "version": "0.7.0-beta-28",
     "description": "Proposal discussion ui",
     "main": "./src/index.js",
     "exports": {

--- a/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
+++ b/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
@@ -841,6 +841,29 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                                 }
                                                                 answerTestId={`proposal-contracting`}
                                                             />
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.bd_proposal_detail
+                                                                ?.data
+                                                                ?.attributes
+                                                                ?.contract_type_name
+                                                                ?.data
+                                                                ?.attributes
+                                                                ?.contract_type_name ===
+                                                                'Other' && (
+                                                                <BudgetDiscussionInfoSegment
+                                                                    question='Please describe what you have in mind.'
+                                                                    answer={
+                                                                        selectedVersion
+                                                                            ?.attributes
+                                                                            ?.bd_proposal_detail
+                                                                            ?.data
+                                                                            ?.attributes
+                                                                            ?.other_contract_type
+                                                                    }
+                                                                    answerTestId={`other-contract-description`}
+                                                                />
+                                                            )}
                                                         </Box>
 
                                                         <Box


### PR DESCRIPTION
## List of changes

- Fix  show other contracting types in budget discussion review and version review / Change version to 28

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3553)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
