### PR TITLE
fix: Missing Character Limit Validation for Link Text in Proposal Sub…

### DIFF
--- a/pdf-ui/src/components/CreationGoveranceAction/LinkManager.jsx
+++ b/pdf-ui/src/components/CreationGoveranceAction/LinkManager.jsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 import { IconPlus, IconX } from '@intersect.mbo/intersectmbo.org-icons-set';
-import { Box, Button, TextField,IconButton } from '@mui/material';
+import { Box, Button, TextField, IconButton } from '@mui/material';
 
 import { isValidURLFormat } from '../../lib/utils';
 
@@ -124,6 +124,8 @@ const LinkManager = ({
                                 }}
                                 inputProps={{
                                     'data-testid': `link-${index}-url-input`,
+                                    //link length limited to 255 characters
+                                    maxLength: 255,
                                 }}
                                 error={!!linksErrors[index]?.url}
                                 helperText={linksErrors[index]?.url}

--- a/pdf-ui/src/components/CreationGoveranceAction/Step3.jsx
+++ b/pdf-ui/src/components/CreationGoveranceAction/Step3.jsx
@@ -184,101 +184,105 @@ const Step3 = ({
                             {proposalData?.prop_rationale || ''}
                         </ReactMarkdown>
                     </Box>
-                    {selectedGATypeId == 2 ?
-                     proposalData?.proposal_withdrawals?.map(
-                     (withdrawal, index) => (
-                                <Box>
-                                    <Box>
-                                        <Typography
-                                            variant='body1'
-                                            color={theme.palette.text.grey}
-                                            gutterBottom
-                                        >
-                                            Receiving address
-                                        </Typography>
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
-                                            data-testid={`receiving-address-${index}-content`}
-                                        >
-                                            {withdrawal.prop_receiving_address}
-                                        </Typography>
-                                    </Box>
-                                    <Box>
-                                        <Typography
-                                            variant='body1'
-                                            color={theme.palette.text.grey}
-                                            gutterBottom
-                                        >
-                                            Amount
-                                        </Typography>
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
-                                            data-testid={`amount-${index}-content`}
-                                        >
-                                            {withdrawal.prop_amount}
-                                        </Typography>
-                                    </Box>
-                                </Box>
-                            )): null }
-                            {selectedGATypeId == 3 && pc ? (
-                                <Box>
-                                    <Box>
-                                        <Typography
-                                            variant='body1'
-                                            color={theme.palette.text.grey}
-                                            gutterBottom
-                                        >
-                                            New constitution URL
-                                        </Typography>
-                                        <Typography
-                                            variant='body1'
-                                            gutterBottom
-                                            data-testid="new-constitution-url-content"
-                                        >
-                                            {pc.prop_constitution_url}
-                                        </Typography>
-                                    </Box>
+                    {selectedGATypeId == 2
+                        ? proposalData?.proposal_withdrawals?.map(
+                              (withdrawal, index) => (
+                                  <Box>
+                                      <Box>
+                                          <Typography
+                                              variant='body1'
+                                              color={theme.palette.text.grey}
+                                              gutterBottom
+                                          >
+                                              Receiving address
+                                          </Typography>
+                                          <Typography
+                                              variant='body1'
+                                              gutterBottom
+                                              data-testid={`receiving-address-${index}-content`}
+                                          >
+                                              {
+                                                  withdrawal.prop_receiving_address
+                                              }
+                                          </Typography>
+                                      </Box>
+                                      <Box>
+                                          <Typography
+                                              variant='body1'
+                                              color={theme.palette.text.grey}
+                                              gutterBottom
+                                          >
+                                              Amount
+                                          </Typography>
+                                          <Typography
+                                              variant='body1'
+                                              gutterBottom
+                                              data-testid={`amount-${index}-content`}
+                                          >
+                                              {withdrawal.prop_amount}
+                                          </Typography>
+                                      </Box>
+                                  </Box>
+                              )
+                          )
+                        : null}
+                    {selectedGATypeId == 3 && pc ? (
+                        <Box>
+                            <Box>
+                                <Typography
+                                    variant='body1'
+                                    color={theme.palette.text.grey}
+                                    gutterBottom
+                                >
+                                    New constitution URL
+                                </Typography>
+                                <Typography
+                                    variant='body1'
+                                    gutterBottom
+                                    data-testid='new-constitution-url-content'
+                                >
+                                    {pc.prop_constitution_url}
+                                </Typography>
+                            </Box>
 
-                                    {pc.prop_have_guardrails_script && (
-                                        <>
-                                            <Box>
-                                                <Typography
-                                                    variant='body1'
-                                                    color={theme.palette.text.grey}
-                                                    gutterBottom
-                                                >
-                                                    Guardrails script URL
-                                                </Typography>
-                                                <Typography
-                                                    variant='body1'
-                                                    gutterBottom
-                                                    data-testid="guardrails-script-url-content"
-                                                >
-                                                    {pc.prop_guardrails_script_url}
-                                                </Typography>
-                                            </Box>
-                                            <Box>
-                                                <Typography
-                                                    variant='body1'
-                                                    color={theme.palette.text.grey}
-                                                    gutterBottom
-                                                >
-                                                    Guardrails script hash
-                                                </Typography>
-                                                <Typography
-                                                    variant='body1'
-                                                    gutterBottom
-                                                    data-testid="guardrails-script-hash-content"
-                                                >
-                                                    {pc.prop_guardrails_script_hash}
-                                                </Typography>
-                                            </Box>
-                                        </>
-                                    )}
-                                </Box>
-                            ) : null}
+                            {pc.prop_have_guardrails_script && (
+                                <>
+                                    <Box>
+                                        <Typography
+                                            variant='body1'
+                                            color={theme.palette.text.grey}
+                                            gutterBottom
+                                        >
+                                            Guardrails script URL
+                                        </Typography>
+                                        <Typography
+                                            variant='body1'
+                                            gutterBottom
+                                            data-testid='guardrails-script-url-content'
+                                        >
+                                            {pc.prop_guardrails_script_url}
+                                        </Typography>
+                                    </Box>
+                                    <Box>
+                                        <Typography
+                                            variant='body1'
+                                            color={theme.palette.text.grey}
+                                            gutterBottom
+                                        >
+                                            Guardrails script hash
+                                        </Typography>
+                                        <Typography
+                                            variant='body1'
+                                            gutterBottom
+                                            data-testid='guardrails-script-hash-content'
+                                        >
+                                            {pc.prop_guardrails_script_hash}
+                                        </Typography>
+                                    </Box>
+                                </>
+                            )}
+                        </Box>
+                    ) : null}
                     {proposalData?.proposal_links?.length > 0 && (
                         <Box>
                             <Typography
@@ -324,6 +328,13 @@ const Step3 = ({
                                             <Typography
                                                 variant='body1'
                                                 component='span'
+                                                sx={{
+                                                    textOverflow: 'ellipsis',
+                                                    overflow: 'hidden',
+                                                    maxWidth: isSmallScreen
+                                                        ? '100%'
+                                                        : '800px',
+                                                }}
                                                 data-testid={`link-${index}-text-content`}
                                             >
                                                 {link?.prop_link_text}


### PR DESCRIPTION
## List of changes

- Fix Missing Character Limit Validation for Link Text in Proposal Submission

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/2337)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
