### PR TITLE
Added is_locked flag in proposals

### DIFF
--- a/backend/public/api-docs/api.yaml
+++ b/backend/public/api-docs/api.yaml
@@ -9197,6 +9197,8 @@ components:
             $ref: '#/components/schemas/ProposalProposalLinkComponent'
         is_draft:
           type: boolean
+        is_locked:
+          type: boolean
         user_id:
           type: string
         prop_submitted:

--- a/backend/src/api/proposal-content/content-types/proposal-content/schema.json
+++ b/backend/src/api/proposal-content/content-types/proposal-content/schema.json
@@ -74,6 +74,10 @@
       "relation": "oneToOne",
       "target": "api::proposal-constitution-content.proposal-constitution-content",
       "mappedBy": "proposal_content"
+    },
+    "is_locked": {
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
## List of changes

- Add 
 Exposed API Flag for Final-State Proposals and Support Lock/Unlock Status for Cosponsor Crowdfunding Integration #3629

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3629)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
