### PR TITLE
Insufficient Balance Modal Appears Despite Having Sufficient Funds fo…

### DIFF
--- a/pdf-ui/src/pages/ProposedGovernanceActions/SingleGovernanceAction/index.jsx
+++ b/pdf-ui/src/pages/ProposedGovernanceActions/SingleGovernanceAction/index.jsx
@@ -36,6 +36,7 @@ import {
     DialogActions,
     DialogContent,
     DialogContentText,
+    badgeClasses,
 } from '@mui/material';
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -152,6 +153,7 @@ const SingleGovernanceAction = ({ id }) => {
     const [truncatedText, setTruncatedText] = useState('');
     const [totalCharLength, setTotalCharLength] = useState(0);
     const [AbstractMarkdownText, setAbstractMarkdownText] = useState('');
+    const [currentWalletBalance, setCurrentWalletBalance] = useState(0);
     const maxLength = 500;
     useEffect(() => {
         if (AbstractMarkdownText.length > maxLength) {
@@ -274,6 +276,15 @@ const SingleGovernanceAction = ({ id }) => {
         }
     };
 
+    const fetchCurrentWalletBalance = async () => {
+        try {
+            const bal = await walletAPI.getBalance();
+            const balance = Number('0x' + bal.match(/^1b([0-9a-fA-F]{16})$/)[1]) || 0;
+            setCurrentWalletBalance(balance/1000000);
+        } catch (error) {
+            console.error(error);
+        }
+    }
     const handleCreateComment = async () => {
         setLoading(true);
         try {
@@ -626,9 +637,9 @@ const SingleGovernanceAction = ({ id }) => {
                                                                     setOpenUsernameModal:
                                                                         setOpenUsernameModal,
                                                                     callBackFn:
-                                                                        () =>{
-                                                                            let bal = (walletAPI?.voter?.votingPower || 0);
-                                                                            if( bal/1000000 >= 100000.18)
+                                                                        () =>{    
+                                                                            fetchCurrentWalletBalance();
+                                                                            if( currentWalletBalance >= 100000.18)
                                                                             {
                                                                                 setOpenGASubmissionDialog(true)
                                                                             }


### PR DESCRIPTION
…r Proposal Submission #3602

## List of changes

- Fix 
  Changed a way how get wallet info so Insufficient balance modal will not appears after this funds check

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3602)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
