### PR TITLE
fix:  Versions of the proposals is not scrolled right way

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
+++ b/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
@@ -232,7 +232,13 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                     </Typography>
                                                 </Box>
                                                 {/* Versions */}
-                                                <List sx={{ padding: 0 }}>
+                                                <List
+                                                    sx={{
+                                                        padding: 0,
+                                                        maxHeight: '70vh',
+                                                        overflowY: 'auto',
+                                                    }}
+                                                >
                                                     {versions?.map(
                                                         (version, index) => (
                                                             <ListItem

--- a/pdf-ui/src/components/ReviewVersions/index.jsx
+++ b/pdf-ui/src/components/ReviewVersions/index.jsx
@@ -63,306 +63,271 @@ const ReviewVersions = ({ open, onClose, id }) => {
 
     return (
         <Typography>
-        <Dialog
-            fullScreen
-            open={open}
-            onClose={onClose}
-            data-testid='review-versions'
-        >
-            {isSmallScreen && openVersionsList ? (
-                <Box>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            justifyContent: 'flex-start',
-                            borderBottom: `1px solid ${theme.palette.border.lightGray}`,
-                            paddingBottom: 2,
-                            marginX: 2,
-                            marginTop: 2,
-                            gap: 2,
-                        }}
-                    >
-                        <IconArchive height='24px' width='24px' />
-                        <Typography variant='h4' component='h1'>
-                            Versions
-                        </Typography>
-                    </Box>
-                    <List>
-                        {versions?.map((version, index) => (
-                            <ListItem
-                                key={version?.attributes?.content?.id || index}
-                                disablePadding
-                                sx={{
-                                    backgroundColor:
-                                        version?.attributes?.content?.id ===
-                                        selectedVersion?.attributes?.content?.id
-                                            ? theme.palette.highlight.blueGray
-                                            : 'transparent',
-                                }}
-                            >
-                                <ListItemButton
-                                    onClick={() => {
-                                        setSelectedVersion(version);
-                                        handleCloseVersionsList();
-                                    }}
-                                    data-testid='review-versions-list-item-button'
-                                >
-                                    <ListItemText
-                                        primary={
-                                            <Box>
-                                                {`${formatIsoDate(
-                                                    version?.attributes?.content
-                                                        ?.attributes?.createdAt
-                                                )}  ${formatIsoTime(
-                                                    version?.attributes?.content
-                                                        ?.attributes?.createdAt
-                                                )} ${
-                                                    version?.attributes?.content
-                                                        ?.attributes
-                                                        ?.prop_rev_active
-                                                        ? ' (Live)'
-                                                        : ''
-                                                }`}
-                                            </Box>
-                                        }
-                                    />
-                                </ListItemButton>
-                            </ListItem>
-                        ))}
-                    </List>
-                </Box>
-            ) : (
-                <Grid
-                    container
-                    sx={{
-                        overflow: 'auto',
-                        minHeight: 0,
-                    }}
-                >
-                    <Grid
-                        item
-                        xs={12}
-                        sx={{
-                            borderBottom: `1px solid ${theme.palette.border.gray}`,
-                            pl: 4,
-                            mt: 2,
-                        }}
-                    >
-                        <Typography variant='h4' component='h1' gutterBottom>
-                            View Versions
-                        </Typography>
-                    </Grid>
-
-                    <Grid item xs={12} m={2}>
-                        <Button
-                            size='small'
-                            startIcon={
-                                <IconCheveronLeft
-                                    width='18'
-                                    height='18'
-                                    fill={theme.palette.primary.main}
-                                />
-                            }
-                            onClick={onClose}
-                            data-testid='review-versions-back'
+            <Dialog
+                fullScreen
+                open={open}
+                onClose={onClose}
+                data-testid='review-versions'
+            >
+                {isSmallScreen && openVersionsList ? (
+                    <Box>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                justifyContent: 'flex-start',
+                                borderBottom: `1px solid ${theme.palette.border.lightGray}`,
+                                paddingBottom: 2,
+                                marginX: 2,
+                                marginTop: 2,
+                                gap: 2,
+                            }}
                         >
-                            Back
-                        </Button>
-                    </Grid>
-
-                    <Grid item xs={12}>
-                        <Grid container spacing={2} px={2}>
-                            <Grid item xs={2}></Grid>
-                            {!isSmallScreen && (
-                                <Grid
-                                    item
-                                    xs={2}
+                            <IconArchive height='24px' width='24px' />
+                            <Typography variant='h4' component='h1'>
+                                Versions
+                            </Typography>
+                        </Box>
+                        <List>
+                            {versions?.map((version, index) => (
+                                <ListItem
+                                    key={
+                                        version?.attributes?.content?.id ||
+                                        index
+                                    }
+                                    disablePadding
                                     sx={{
-                                        padding: 0,
-                                        marginRight: 0,
-                                        marginLeft: 2,
+                                        backgroundColor:
+                                            version?.attributes?.content?.id ===
+                                            selectedVersion?.attributes?.content
+                                                ?.id
+                                                ? theme.palette.highlight
+                                                      .blueGray
+                                                : 'transparent',
                                     }}
                                 >
-                                    <Card variant='outlined'>
-                                        <CardContent
-                                            sx={{
-                                                padding: 0,
-                                                width: '100%',
-                                            }}
-                                        >
-                                            <Box
+                                    <ListItemButton
+                                        onClick={() => {
+                                            setSelectedVersion(version);
+                                            handleCloseVersionsList();
+                                        }}
+                                        data-testid='review-versions-list-item-button'
+                                    >
+                                        <ListItemText
+                                            primary={
+                                                <Box>
+                                                    {`${formatIsoDate(
+                                                        version?.attributes
+                                                            ?.content
+                                                            ?.attributes
+                                                            ?.createdAt
+                                                    )}  ${formatIsoTime(
+                                                        version?.attributes
+                                                            ?.content
+                                                            ?.attributes
+                                                            ?.createdAt
+                                                    )} ${
+                                                        version?.attributes
+                                                            ?.content
+                                                            ?.attributes
+                                                            ?.prop_rev_active
+                                                            ? ' (Live)'
+                                                            : ''
+                                                    }`}
+                                                </Box>
+                                            }
+                                        />
+                                    </ListItemButton>
+                                </ListItem>
+                            ))}
+                        </List>
+                    </Box>
+                ) : (
+                    <Grid
+                        container
+                        sx={{
+                            overflow: 'auto',
+                            minHeight: 0,
+                        }}
+                    >
+                        <Grid
+                            item
+                            xs={12}
+                            sx={{
+                                borderBottom: `1px solid ${theme.palette.border.gray}`,
+                                pl: 4,
+                                mt: 2,
+                            }}
+                        >
+                            <Typography
+                                variant='h4'
+                                component='h1'
+                                gutterBottom
+                            >
+                                View Versions
+                            </Typography>
+                        </Grid>
+
+                        <Grid item xs={12} m={2}>
+                            <Button
+                                size='small'
+                                startIcon={
+                                    <IconCheveronLeft
+                                        width='18'
+                                        height='18'
+                                        fill={theme.palette.primary.main}
+                                    />
+                                }
+                                onClick={onClose}
+                                data-testid='review-versions-back'
+                            >
+                                Back
+                            </Button>
+                        </Grid>
+
+                        <Grid item xs={12}>
+                            <Grid container spacing={2} px={2}>
+                                <Grid item xs={2}></Grid>
+                                {!isSmallScreen && (
+                                    <Grid
+                                        item
+                                        xs={2}
+                                        sx={{
+                                            padding: 0,
+                                            marginRight: 0,
+                                            marginLeft: 2,
+                                        }}
+                                    >
+                                        <Card variant='outlined'>
+                                            <CardContent
                                                 sx={{
-                                                    display: 'flex',
-                                                    flexDirection: 'row',
-                                                    justifyContent:
-                                                        'flex-start',
-                                                    alignContent: 'center',
-                                                    borderBottom: `1px solid ${theme.palette.border.lightGray}`,
-                                                    gap: 2,
-                                                    m: 2,
-                                                    pb: 1,
+                                                    padding: 0,
+                                                    width: '100%',
                                                 }}
                                             >
-                                                <IconArchive
-                                                    height='24px'
-                                                    width='24px'
-                                                />
-                                                <Typography variant='subtitle1'>
-                                                    Versions
-                                                </Typography>
-                                            </Box>
-                                            {/* Versions */}
-                                            <List sx={{ padding: 0 }}>
-                                                {versions?.map(
-                                                    (version, index) => (
-                                                        <ListItem
-                                                            key={
-                                                                version
-                                                                    ?.attributes
-                                                                    ?.content
-                                                                    ?.id ||
-                                                                index
-                                                            }
-                                                            disablePadding
-                                                            sx={{
-                                                                backgroundColor:
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        flexDirection: 'row',
+                                                        justifyContent:
+                                                            'flex-start',
+                                                        alignContent: 'center',
+                                                        borderBottom: `1px solid ${theme.palette.border.lightGray}`,
+                                                        gap: 2,
+                                                        m: 2,
+                                                        pb: 1,
+                                                    }}
+                                                >
+                                                    <IconArchive
+                                                        height='24px'
+                                                        width='24px'
+                                                    />
+                                                    <Typography variant='subtitle1'>
+                                                        Versions
+                                                    </Typography>
+                                                </Box>
+                                                {/* Versions */}
+                                                <List
+                                                    sx={{
+                                                        padding: 0,
+                                                        maxHeight: '70vh',
+                                                        overflowY: 'auto',
+                                                    }}
+                                                >
+                                                    {versions?.map(
+                                                        (version, index) => (
+                                                            <ListItem
+                                                                key={
                                                                     version
                                                                         ?.attributes
                                                                         ?.content
-                                                                        ?.id ===
-                                                                    selectedVersion
-                                                                        ?.attributes
-                                                                        ?.content
-                                                                        ?.id
-                                                                        ? theme
-                                                                              .palette
-                                                                              .highlight
-                                                                              .blueGray
-                                                                        : 'transparent',
-                                                            }}
-                                                        >
-                                                            <ListItemButton
-                                                                onClick={() =>
-                                                                    setSelectedVersion(
-                                                                        version
-                                                                    )
+                                                                        ?.id ||
+                                                                    index
                                                                 }
+                                                                disablePadding
+                                                                sx={{
+                                                                    backgroundColor:
+                                                                        version
+                                                                            ?.attributes
+                                                                            ?.content
+                                                                            ?.id ===
+                                                                        selectedVersion
+                                                                            ?.attributes
+                                                                            ?.content
+                                                                            ?.id
+                                                                            ? theme
+                                                                                  .palette
+                                                                                  .highlight
+                                                                                  .blueGray
+                                                                            : 'transparent',
+                                                                }}
                                                             >
-                                                                <ListItemText
-                                                                    primary={
-                                                                        <>
-                                                                            <div>
-                                                                                {`${formatIsoDate(
-                                                                                    version
-                                                                                        ?.attributes
-                                                                                        ?.content
-                                                                                        ?.attributes
-                                                                                        ?.createdAt
-                                                                                )}${
-                                                                                    version
-                                                                                        ?.attributes
-                                                                                        ?.content
-                                                                                        ?.attributes
-                                                                                        ?.prop_rev_active
-                                                                                        ? ' (Live)'
-                                                                                        : ''
-                                                                                }`}
-                                                                            </div>
-                                                                            <div>
-                                                                                {formatIsoTime(
-                                                                                    version
-                                                                                        ?.attributes
-                                                                                        ?.content
-                                                                                        ?.attributes
-                                                                                        ?.createdAt
-                                                                                )}
-                                                                            </div>
-                                                                        </>
+                                                                <ListItemButton
+                                                                    onClick={() =>
+                                                                        setSelectedVersion(
+                                                                            version
+                                                                        )
                                                                     }
-                                                                />
-                                                            </ListItemButton>
-                                                        </ListItem>
-                                                    )
-                                                )}
-                                            </List>
-                                        </CardContent>
-                                    </Card>
-                                </Grid>
-                            )}
-                            {/* Selected version content */}
-                            <Grid item xs={12} md={6} zIndex={1}>
-                                <Box display={'flex'} width={'100%'}>
-                                    <Card
-                                        variant='outlined'
-                                        sx={{ width: '100%' }}
-                                    >
-                                        <CardContent>
-                                            <Box
-                                                sx={{
-                                                    display: 'flex',
-                                                    flexDirection: 'column',
-                                                    textAlign: 'justify',
-                                                    gap: 2,
-                                                }}
-                                            >
-                                                <Typography
-                                                    variant='h5'
-                                                    gutterBottom
+                                                                >
+                                                                    <ListItemText
+                                                                        primary={
+                                                                            <>
+                                                                                <div>
+                                                                                    {`${formatIsoDate(
+                                                                                        version
+                                                                                            ?.attributes
+                                                                                            ?.content
+                                                                                            ?.attributes
+                                                                                            ?.createdAt
+                                                                                    )}${
+                                                                                        version
+                                                                                            ?.attributes
+                                                                                            ?.content
+                                                                                            ?.attributes
+                                                                                            ?.prop_rev_active
+                                                                                            ? ' (Live)'
+                                                                                            : ''
+                                                                                    }`}
+                                                                                </div>
+                                                                                <div>
+                                                                                    {formatIsoTime(
+                                                                                        version
+                                                                                            ?.attributes
+                                                                                            ?.content
+                                                                                            ?.attributes
+                                                                                            ?.createdAt
+                                                                                    )}
+                                                                                </div>
+                                                                            </>
+                                                                        }
+                                                                    />
+                                                                </ListItemButton>
+                                                            </ListItem>
+                                                        )
+                                                    )}
+                                                </List>
+                                            </CardContent>
+                                        </Card>
+                                    </Grid>
+                                )}
+                                {/* Selected version content */}
+                                <Grid item xs={12} md={6} zIndex={1}>
+                                    <Box display={'flex'} width={'100%'}>
+                                        <Card
+                                            variant='outlined'
+                                            sx={{ width: '100%' }}
+                                        >
+                                            <CardContent>
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        flexDirection: 'column',
+                                                        textAlign: 'justify',
+                                                        gap: 2,
+                                                    }}
                                                 >
-                                                    {
-                                                        selectedVersion
-                                                            ?.attributes
-                                                            ?.content
-                                                            ?.attributes
-                                                            ?.prop_name
-                                                    }
-                                                </Typography>
-                                                {isSmallScreen ? (
-                                                    <Box>
-                                                        <Typography
-                                                            variant='body1'
-                                                            color={
-                                                                theme.palette
-                                                                    .text.grey
-                                                            }
-                                                        >
-                                                            Version Date
-                                                        </Typography>
-                                                        <Typography
-                                                            variant='body1'
-                                                            gutterBottom
-                                                        >
-                                                            {`${formatIsoDate(
-                                                                selectedVersion
-                                                                    ?.attributes
-                                                                    ?.content
-                                                                    ?.attributes
-                                                                    ?.createdAt
-                                                            )}${
-                                                                selectedVersion
-                                                                    ?.attributes
-                                                                    ?.content
-                                                                    ?.attributes
-                                                                    ?.prop_rev_active
-                                                                    ? ' (Live)'
-                                                                    : ''
-                                                            }`}
-                                                        </Typography>
-                                                    </Box>
-                                                ) : null}
-                                                <Box>
                                                     <Typography
-                                                        variant='body1'
-                                                        color={
-                                                            theme.palette.text
-                                                                .grey
-                                                        }
-                                                    >
-                                                        Goverance Action Type
-                                                    </Typography>
-                                                    <Typography
-                                                        variant='body1'
+                                                        variant='h5'
                                                         gutterBottom
                                                     >
                                                         {
@@ -370,138 +335,44 @@ const ReviewVersions = ({ open, onClose, id }) => {
                                                                 ?.attributes
                                                                 ?.content
                                                                 ?.attributes
-                                                                ?.gov_action_type
-                                                                ?.attributes
-                                                                ?.gov_action_type_name
+                                                                ?.prop_name
                                                         }
                                                     </Typography>
-                                                </Box>
-                                                <Box>
-                                                    <Typography
-                                                        variant='body1'
-                                                        color={
-                                                            theme.palette.text
-                                                                .grey
-                                                        }
-                                                    >
-                                                        Abstract
-                                                    </Typography>
-                                                    <ReactMarkdown
-                                                        components={{
-                                                            p(props) {
-                                                                const {
-                                                                    children,
-                                                                } = props;
-                                                                return (
-                                                                    <Typography
-                                                                        variant='body1'
-                                                                        style={{
-                                                                            wordWrap:
-                                                                                'break-word',
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            children
-                                                                        }
-                                                                    </Typography>
-                                                                );
-                                                            },
-                                                        }}
-                                                    >
-                                                        {selectedVersion
-                                                            ?.attributes
-                                                            ?.content
-                                                            ?.attributes
-                                                            ?.prop_abstract ||
-                                                            ''}
-                                                    </ReactMarkdown>
-                                                </Box>
-                                                <Box>
-                                                    <Typography
-                                                        variant='body1'
-                                                        color={
-                                                            theme.palette.text
-                                                                .grey
-                                                        }
-                                                    >
-                                                        Motivation
-                                                    </Typography>
-                                                    <ReactMarkdown
-                                                        components={{
-                                                            p(props) {
-                                                                const {
-                                                                    children,
-                                                                } = props;
-                                                                return (
-                                                                    <Typography
-                                                                        variant='body1'
-                                                                        style={{
-                                                                            wordWrap:
-                                                                                'break-word',
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            children
-                                                                        }
-                                                                    </Typography>
-                                                                );
-                                                            },
-                                                        }}
-                                                    >
-                                                        {selectedVersion
-                                                            ?.attributes
-                                                            ?.content
-                                                            ?.attributes
-                                                            ?.prop_motivation ||
-                                                            ''}
-                                                    </ReactMarkdown>
-                                                </Box>
-                                                <Box>
-                                                    <Typography
-                                                        variant='body1'
-                                                        color={
-                                                            theme.palette.text
-                                                                .grey
-                                                        }
-                                                    >
-                                                        Rationale
-                                                    </Typography>
-
-                                                    <ReactMarkdown
-                                                        components={{
-                                                            p(props) {
-                                                                const {
-                                                                    children,
-                                                                } = props;
-                                                                return (
-                                                                    <Typography
-                                                                        variant='body1'
-                                                                        style={{
-                                                                            wordWrap:
-                                                                                'break-word',
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            children
-                                                                        }
-                                                                    </Typography>
-                                                                );
-                                                            },
-                                                        }}
-                                                    >
-                                                        {selectedVersion
-                                                            ?.attributes
-                                                            ?.content
-                                                            ?.attributes
-                                                            ?.prop_rationale ||
-                                                            ''}
-                                                    </ReactMarkdown>
-                                                </Box>
-
-                                                {selectedVersion?.attributes
-                                                    ?.content?.attributes
-                                                    ?.proposal_links?.length >
-                                                    0 && (
+                                                    {isSmallScreen ? (
+                                                        <Box>
+                                                            <Typography
+                                                                variant='body1'
+                                                                color={
+                                                                    theme
+                                                                        .palette
+                                                                        .text
+                                                                        .grey
+                                                                }
+                                                            >
+                                                                Version Date
+                                                            </Typography>
+                                                            <Typography
+                                                                variant='body1'
+                                                                gutterBottom
+                                                            >
+                                                                {`${formatIsoDate(
+                                                                    selectedVersion
+                                                                        ?.attributes
+                                                                        ?.content
+                                                                        ?.attributes
+                                                                        ?.createdAt
+                                                                )}${
+                                                                    selectedVersion
+                                                                        ?.attributes
+                                                                        ?.content
+                                                                        ?.attributes
+                                                                        ?.prop_rev_active
+                                                                        ? ' (Live)'
+                                                                        : ''
+                                                                }`}
+                                                            </Typography>
+                                                        </Box>
+                                                    ) : null}
                                                     <Box>
                                                         <Typography
                                                             variant='body1'
@@ -510,132 +381,289 @@ const ReviewVersions = ({ open, onClose, id }) => {
                                                                     .text.grey
                                                             }
                                                         >
-                                                            Supporting links
+                                                            Goverance Action
+                                                            Type
                                                         </Typography>
-                                                        <Box
-                                                            display='flex'
-                                                            flexDirection={
-                                                                isSmallScreen
-                                                                    ? 'column'
-                                                                    : 'row'
-                                                            }
-                                                            flexWrap='wrap'
-                                                            gap={2}
+                                                        <Typography
+                                                            variant='body1'
+                                                            gutterBottom
                                                         >
-                                                            {selectedVersion?.attributes?.content?.attributes?.proposal_links?.map(
-                                                                (
-                                                                    link,
-                                                                    index
-                                                                ) => (
-                                                                    <Box
-                                                                        key={
-                                                                            index
-                                                                        }
-                                                                        display='flex'
-                                                                        flexDirection='row'
-                                                                        alignItems='center'
-                                                                        component={
-                                                                            Button
-                                                                        }
-                                                                        onClick={() =>
-                                                                            openLink(
-                                                                                link?.prop_link
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        <Box
-                                                                            mr={
-                                                                                0.5
-                                                                            }
-                                                                        >
-                                                                            <IconLink
-                                                                                fill={
-                                                                                    theme
-                                                                                        .palette
-                                                                                        .primary
-                                                                                        .main
-                                                                                }
-                                                                            />
-                                                                        </Box>
+                                                            {
+                                                                selectedVersion
+                                                                    ?.attributes
+                                                                    ?.content
+                                                                    ?.attributes
+                                                                    ?.gov_action_type
+                                                                    ?.attributes
+                                                                    ?.gov_action_type_name
+                                                            }
+                                                        </Typography>
+                                                    </Box>
+                                                    <Box>
+                                                        <Typography
+                                                            variant='body1'
+                                                            color={
+                                                                theme.palette
+                                                                    .text.grey
+                                                            }
+                                                        >
+                                                            Abstract
+                                                        </Typography>
+                                                        <ReactMarkdown
+                                                            components={{
+                                                                p(props) {
+                                                                    const {
+                                                                        children,
+                                                                    } = props;
+                                                                    return (
                                                                         <Typography
-                                                                            variant='body2'
-                                                                            component='span'
-                                                                            data-testid={`link-${index}-text-content`}
+                                                                            variant='body1'
+                                                                            style={{
+                                                                                wordWrap:
+                                                                                    'break-word',
+                                                                            }}
                                                                         >
                                                                             {
-                                                                                link?.prop_link_text
+                                                                                children
                                                                             }
                                                                         </Typography>
-                                                                    </Box>
-                                                                )
-                                                            )}
-                                                        </Box>
+                                                                    );
+                                                                },
+                                                            }}
+                                                        >
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.content
+                                                                ?.attributes
+                                                                ?.prop_abstract ||
+                                                                ''}
+                                                        </ReactMarkdown>
                                                     </Box>
-                                                )}
-                                            </Box>
+                                                    <Box>
+                                                        <Typography
+                                                            variant='body1'
+                                                            color={
+                                                                theme.palette
+                                                                    .text.grey
+                                                            }
+                                                        >
+                                                            Motivation
+                                                        </Typography>
+                                                        <ReactMarkdown
+                                                            components={{
+                                                                p(props) {
+                                                                    const {
+                                                                        children,
+                                                                    } = props;
+                                                                    return (
+                                                                        <Typography
+                                                                            variant='body1'
+                                                                            style={{
+                                                                                wordWrap:
+                                                                                    'break-word',
+                                                                            }}
+                                                                        >
+                                                                            {
+                                                                                children
+                                                                            }
+                                                                        </Typography>
+                                                                    );
+                                                                },
+                                                            }}
+                                                        >
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.content
+                                                                ?.attributes
+                                                                ?.prop_motivation ||
+                                                                ''}
+                                                        </ReactMarkdown>
+                                                    </Box>
+                                                    <Box>
+                                                        <Typography
+                                                            variant='body1'
+                                                            color={
+                                                                theme.palette
+                                                                    .text.grey
+                                                            }
+                                                        >
+                                                            Rationale
+                                                        </Typography>
 
+                                                        <ReactMarkdown
+                                                            components={{
+                                                                p(props) {
+                                                                    const {
+                                                                        children,
+                                                                    } = props;
+                                                                    return (
+                                                                        <Typography
+                                                                            variant='body1'
+                                                                            style={{
+                                                                                wordWrap:
+                                                                                    'break-word',
+                                                                            }}
+                                                                        >
+                                                                            {
+                                                                                children
+                                                                            }
+                                                                        </Typography>
+                                                                    );
+                                                                },
+                                                            }}
+                                                        >
+                                                            {selectedVersion
+                                                                ?.attributes
+                                                                ?.content
+                                                                ?.attributes
+                                                                ?.prop_rationale ||
+                                                                ''}
+                                                        </ReactMarkdown>
+                                                    </Box>
+
+                                                    {selectedVersion?.attributes
+                                                        ?.content?.attributes
+                                                        ?.proposal_links
+                                                        ?.length > 0 && (
+                                                        <Box>
+                                                            <Typography
+                                                                variant='body1'
+                                                                color={
+                                                                    theme
+                                                                        .palette
+                                                                        .text
+                                                                        .grey
+                                                                }
+                                                            >
+                                                                Supporting links
+                                                            </Typography>
+                                                            <Box
+                                                                display='flex'
+                                                                flexDirection={
+                                                                    isSmallScreen
+                                                                        ? 'column'
+                                                                        : 'row'
+                                                                }
+                                                                flexWrap='wrap'
+                                                                gap={2}
+                                                            >
+                                                                {selectedVersion?.attributes?.content?.attributes?.proposal_links?.map(
+                                                                    (
+                                                                        link,
+                                                                        index
+                                                                    ) => (
+                                                                        <Box
+                                                                            key={
+                                                                                index
+                                                                            }
+                                                                            display='flex'
+                                                                            flexDirection='row'
+                                                                            alignItems='center'
+                                                                            component={
+                                                                                Button
+                                                                            }
+                                                                            onClick={() =>
+                                                                                openLink(
+                                                                                    link?.prop_link
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Box
+                                                                                mr={
+                                                                                    0.5
+                                                                                }
+                                                                            >
+                                                                                <IconLink
+                                                                                    fill={
+                                                                                        theme
+                                                                                            .palette
+                                                                                            .primary
+                                                                                            .main
+                                                                                    }
+                                                                                />
+                                                                            </Box>
+                                                                            <Typography
+                                                                                variant='body2'
+                                                                                component='span'
+                                                                                data-testid={`link-${index}-text-content`}
+                                                                            >
+                                                                                {
+                                                                                    link?.prop_link_text
+                                                                                }
+                                                                            </Typography>
+                                                                        </Box>
+                                                                    )
+                                                                )}
+                                                            </Box>
+                                                        </Box>
+                                                    )}
+                                                </Box>
+
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        flexDirection:
+                                                            isSmallScreen
+                                                                ? 'column'
+                                                                : 'row',
+                                                        justifyContent:
+                                                            'space-between',
+                                                        mt: 10,
+                                                    }}
+                                                >
+                                                    <Box>
+                                                        <Button
+                                                            variant='outlined'
+                                                            sx={{
+                                                                mb: {
+                                                                    xs: 2,
+                                                                    md: 0,
+                                                                },
+                                                            }}
+                                                            onClick={onClose}
+                                                            data-testid='back-button'
+                                                        >
+                                                            Back to Proposal
+                                                        </Button>
+                                                    </Box>
+                                                </Box>
+                                            </CardContent>
+                                        </Card>
+
+                                        {isSmallScreen && (
                                             <Box
+                                                ml={2}
                                                 sx={{
                                                     display: 'flex',
-                                                    flexDirection: isSmallScreen
-                                                        ? 'column'
-                                                        : 'row',
-                                                    justifyContent:
-                                                        'space-between',
-                                                    mt: 10,
+                                                    justifyContent: 'center',
+                                                    alignItems: 'center',
+                                                    backgroundColor:
+                                                        theme.palette.iconButton
+                                                            .lightPeriwinkle,
+                                                    borderRadius: '16px',
+                                                    width: '40px',
+                                                    height: '40px',
+                                                    boxShadow:
+                                                        '0px 4px 15px 0px #DDE3F5',
                                                 }}
                                             >
-                                                <Box>
-                                                    <Button
-                                                        variant='outlined'
-                                                        sx={{
-                                                            mb: {
-                                                                xs: 2,
-                                                                md: 0,
-                                                            },
-                                                        }}
-                                                        onClick={onClose}
-                                                        data-testid='back-button'
-                                                    >
-                                                        Back to Proposal
-                                                    </Button>
-                                                </Box>
+                                                <IconButton
+                                                    onClick={
+                                                        handleOpenVersionsList
+                                                    }
+                                                    data-testid='versions-button'
+                                                >
+                                                    <IconArchive />
+                                                </IconButton>
                                             </Box>
-                                        </CardContent>
-                                    </Card>
-
-                                    {isSmallScreen && (
-                                        <Box
-                                            ml={2}
-                                            sx={{
-                                                display: 'flex',
-                                                justifyContent: 'center',
-                                                alignItems: 'center',
-                                                backgroundColor:
-                                                    theme.palette.iconButton
-                                                        .lightPeriwinkle,
-                                                borderRadius: '16px',
-                                                width: '40px',
-                                                height: '40px',
-                                                boxShadow:
-                                                    '0px 4px 15px 0px #DDE3F5',
-                                            }}
-                                        >
-                                            <IconButton
-                                                onClick={handleOpenVersionsList}
-                                                data-testid='versions-button'
-                                            >
-                                                <IconArchive />
-                                            </IconButton>
-                                        </Box>
-                                    )}
-                                </Box>
+                                        )}
+                                    </Box>
+                                </Grid>
                             </Grid>
                         </Grid>
                     </Grid>
-                </Grid>
-            )}
-        </Dialog>
+                )}
+            </Dialog>
         </Typography>
     );
 };


### PR DESCRIPTION
## List of changes

-  Fix  Versions of the proposals is not scrolled right way

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3084)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
