### PR TITLE
fix: Remove unnecessary optional chaining for content attribute in Bu…

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -8,15 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [v0.7.0-beta-28](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-30) 2025-05-26
+
+### Fixed
+
+-   fix: Update data-testid attributes for improved accessibility in form…
+-   Hardware Wallet warning #2575
+-   fix: Refactor sorting mechanism in BudgetDiscussionsList and Proposed…
+-   fix: Update aria-labelledby attribute for sort button and pass isDraf…
+-   feat: Enhanced Markdown rendering to support additional tags and styl…
+-   fix: Remove unnecessary optional chaining for content attribute in BudgetDiscussionReviewVersions component
+
+### Added
+-   feat/ Implement Infinite Scroll for Proposal Discussion Forum Section…
+
 ## [v0.7.0-beta-28](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-29) 2025-05-15
 
 ### Fixed
+
 -   fix: display message when bd is submited for vote and hidden the poll
 -   fix: Missing Character Limit Validation for Link Text in Proposal Submission
 
 ## [v0.7.0-beta-28](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-28) 2025-05-15
 
 ### Fixed
+
 -   fix: [Bug: "Other" Contracting Method Details Not Displayed in Review](https://github.com/IntersectMBO/govtool/issues/3553)
 
 ## [v0.7.0-beta-27](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-27) 2025-05-14

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@intersect.mbo/pdf-ui",
-    "version": "0.7.0-beta-29",
+    "version": "0.7.0-beta-30",
     "description": "Proposal discussion ui",
     "main": "./src/index.js",
     "exports": {

--- a/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
+++ b/pdf-ui/src/components/BudgetDiscussionReviewVersions/index.js
@@ -345,8 +345,6 @@ const BudgetDiscussionReviewVersions = ({ open, onClose, id }) => {
                                                                 {`${formatIsoDate(
                                                                     selectedVersion
                                                                         ?.attributes
-                                                                        ?.content
-                                                                        ?.attributes
                                                                         ?.createdAt
                                                                 )}${
                                                                     selectedVersion


### PR DESCRIPTION
## List of changes

-Fix Remove unnecessary optional chaining for content attribute in BudgetDiscussionReviewVersions component
-Add: Update version to 0.7.0-beta-30 and enhance changelog with recent fixes and features

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3452)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
