### PR TITLE
Fix:Remove CSS Rounded Edges on Proposal Creation Pages on background…

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
+## [v0.7.0-beta-31](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-31) 2025-05-28
+### Fixed
+-   feat: Enhanced Markdown rendering to support additional tags and styl…
+-   fix: Update data-testid attributes for improved accessibility in form…
+-   Hardware Wallet warning #2575
+-   fix: Refactor sorting mechanism in BudgetDiscussionsList and Proposed…
+-   fix: Remove unnecessary optional chaining for content attribute in Bu…
+-   chore: Refactor link management and validation in Budget Discussion c…
+-   Added search by submition hash
+-   Hardware wallet removed check, just message left
+-   Fix Insufficient Balance check
+-   Fix labeling for USD to ADA conversation rate #3692
+-   feat: Enhance sorting functionality in ProposalsList and ProposedGove…
+
 
 ## [v0.7.0-beta-28](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/0.7.0-beta-30) 2025-05-26
 

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@intersect.mbo/pdf-ui",
-    "version": "0.7.0-beta-30",
+    "version": "0.7.0-beta-31",
     "description": "Proposal discussion ui",
     "main": "./src/index.js",
     "exports": {

--- a/pdf-ui/src/components/CreateBudgetDiscussionDialog/index.jsx
+++ b/pdf-ui/src/components/CreateBudgetDiscussionDialog/index.jsx
@@ -521,6 +521,9 @@ const CreateBudgetDiscussionDialog = ({
             open={open}
             onClose={onClose}
             data-testid='create-budget-discussion-dialog'
+            PaperProps={{
+                sx: { borderRadius: 0 },
+            }}
         >
             <Box
                 sx={{

--- a/pdf-ui/src/components/CreateGovernanceActionDialog/index.jsx
+++ b/pdf-ui/src/components/CreateGovernanceActionDialog/index.jsx
@@ -30,13 +30,13 @@ const CreateGovernanceActionDialog = ({ open = false, onClose = false }) => {
     const [proposalData, setProposalData] = useState({
         proposal_links: [],
         proposal_withdrawals: [],
-        proposal_constitution_content:{}
+        proposal_constitution_content: {},
     });
-
 
     const [governanceActionTypes, setGovernanceActionTypes] = useState([]);
     const [isContinueDisabled, setIsContinueDisabled] = useState(true);
-    const [showDraftSuccessfulModal, setShowDraftSuccessfulModal] = useState(false);
+    const [showDraftSuccessfulModal, setShowDraftSuccessfulModal] =
+        useState(false);
     const [selectedDraftId, setSelectedDraftId] = useState(null);
     const [errors, setErrors] = useState({
         name: false,
@@ -52,8 +52,8 @@ const CreateGovernanceActionDialog = ({ open = false, onClose = false }) => {
     });
 
     const [linksErrors, setLinksErrors] = useState({});
-    const [withdrawalsErrors, setWithdrawalsErrors ] = useState({});
-    const [constitutionErrors,setConstitutionErrors] = useState({});
+    const [withdrawalsErrors, setWithdrawalsErrors] = useState({});
+    const [constitutionErrors, setConstitutionErrors] = useState({});
     const isSmallScreen = useMediaQuery((theme) =>
         theme.breakpoints.down('sm')
     );
@@ -99,38 +99,61 @@ const CreateGovernanceActionDialog = ({ open = false, onClose = false }) => {
             const selectedLabel = governanceActionTypes.find(
                 (option) => option?.value === proposalData?.gov_action_type_id
             )?.label;
-            const selectedType = governanceActionTypes.find((option) => option?.value === proposalData?.gov_action_type_id)?.value;
+            const selectedType = governanceActionTypes.find(
+                (option) => option?.value === proposalData?.gov_action_type_id
+            )?.value;
             if (proposalData?.gov_action_type_id == 2) {
                 if (proposalData?.proposal_withdrawals) {
-                     if (
-                         proposalData?.proposal_withdrawals?.some(
-                             (proposal_withdrawal) => !proposal_withdrawal.prop_receiving_address || !proposal_withdrawal.prop_amount
-                         ) ||
-                         Object.values(withdrawalsErrors).some(
-                            (errors) =>!errors.prop_amount== '' || !errors.prop_receiving_address ==''
-                        ) ){
+                    if (
+                        proposalData?.proposal_withdrawals?.some(
+                            (proposal_withdrawal) =>
+                                !proposal_withdrawal.prop_receiving_address ||
+                                !proposal_withdrawal.prop_amount
+                        ) ||
+                        Object.values(withdrawalsErrors).some(
+                            (errors) =>
+                                !errors.prop_amount == '' ||
+                                !errors.prop_receiving_address == ''
+                        )
+                    ) {
                         return setIsContinueDisabled(true);
                     } else {
                         setIsContinueDisabled(false);
                     }
                 }
-            } 
+            }
             if (proposalData?.gov_action_type_id == 3) {
-                if(!proposalData?.proposal_constitution_content?.prop_constitution_url || constitutionErrors?.prop_constitution_url)
+                if (
+                    !proposalData?.proposal_constitution_content
+                        ?.prop_constitution_url ||
+                    constitutionErrors?.prop_constitution_url
+                )
                     return setIsContinueDisabled(true);
-                if(proposalData?.proposal_constitution_content?.prop_have_guardrails_script)
-                {
-                    if(!proposalData?.proposal_constitution_content.prop_guardrails_script_url || !proposalData?.proposal_constitution_content.prop_guardrails_script_hash)
-                       return setIsContinueDisabled(true);
-                }
-                else {
+                if (
+                    proposalData?.proposal_constitution_content
+                        ?.prop_have_guardrails_script
+                ) {
+                    if (
+                        !proposalData?.proposal_constitution_content
+                            .prop_guardrails_script_url ||
+                        !proposalData?.proposal_constitution_content
+                            .prop_guardrails_script_hash
+                    )
+                        return setIsContinueDisabled(true);
+                } else {
                     setIsContinueDisabled(false);
                 }
             }
         } else {
             setIsContinueDisabled(true);
         }
-    }, [proposalData, errors, linksErrors, withdrawalsErrors, constitutionErrors]); // proposalData is a dependency
+    }, [
+        proposalData,
+        errors,
+        linksErrors,
+        withdrawalsErrors,
+        constitutionErrors,
+    ]); // proposalData is a dependency
     // useEffect(() => {
     //     handleIsContinueDisabled()
     // },[proposalData])
@@ -187,6 +210,9 @@ const CreateGovernanceActionDialog = ({ open = false, onClose = false }) => {
             open={open}
             onClose={onClose}
             data-testid='create-governance-action-dialog'
+            PaperProps={{
+                sx: { borderRadius: 0 },
+            }}
         >
             <Box
                 sx={{
@@ -280,7 +306,9 @@ const CreateGovernanceActionDialog = ({ open = false, onClose = false }) => {
                                     withdrawalsErrors={withdrawalsErrors}
                                     setWithdrawalsErrors={setWithdrawalsErrors}
                                     constitutionErrors={constitutionErrors}
-                                    setConstitutionErrors={setConstitutionErrors}
+                                    setConstitutionErrors={
+                                        setConstitutionErrors
+                                    }
                                 />
                             )}
 


### PR DESCRIPTION
## List of changes

-  Fix Remove CSS Rounded Edges on Proposal Creation Pages on background, Update version to 31

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3690)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
