### PR TITLE
fix: Add Markdown Table Support in Proposal Discussion Forum

### DIFF
--- a/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
+++ b/pdf-ui/src/components/BudgetDiscussionCard/index.jsx
@@ -379,6 +379,15 @@ const BudgetDiscussionCard = ({
                                         ? `draft-proposal-benefit`
                                         : 'proposal-benefit'
                                 }
+                                style={{
+                                    display: '-webkit-box',
+                                    WebkitBoxOrient: 'vertical',
+                                    WebkitLineClamp: 3,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    lineHeight: '1.5',
+                                    maxHeight: '4.5em',
+                                }}
                             >
                                 <MarkdownTypography
                                     content={

--- a/pdf-ui/src/components/ProposalCard/index.jsx
+++ b/pdf-ui/src/components/ProposalCard/index.jsx
@@ -318,14 +318,26 @@ const ProposalCard = ({
                             >
                                 Abstract
                             </Typography>
+                            <div
+                                style={{
+                                    display: '-webkit-box',
+                                    WebkitBoxOrient: 'vertical',
+                                    WebkitLineClamp: 3,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    lineHeight: '1.5',
+                                    maxHeight: '4.5em',
+                                }}
+                            >
+                                <MarkdownTypography
+                                    content={
+                                        proposal?.attributes?.content
+                                            ?.attributes?.prop_abstract || ''
+                                    }
+                                    testId={`abstract-content`}
+                                />
+                            </div>
 
-                            <MarkdownTypography
-                                content={
-                                    proposal?.attributes?.content?.attributes
-                                        ?.prop_abstract || ''
-                                }
-                                testId={`abstract-content`}
-                            />
                             {/* <MarkdownTextComponent
                                 markdownText={
                                     proposal?.attributes?.content?.attributes


### PR DESCRIPTION
## List of changes

-  Fix Add Markdown Table Support in Proposal Discussion Forum #3616

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/3616)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
