### PR TITLE
Fix/ submitting governance action with ipfs metadata url fails due to unsupported url scheme (#3979)

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [v1.0.10-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.10-beta) 2025-07-29
+-   Submitting Governance Action with IPFS Metadata URL Fails Due to Unsupported URL Scheme #3979
+
 ## [v1.0.9-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.9-beta) 2025-07-03
 -   Support IPFS Links for Governance Action Submissions #3851
 

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@intersect.mbo/pdf-ui",
-    "version": "1.0.9-beta",
+    "version": "1.0.10-beta",
     "description": "Proposal discussion ui",
     "main": "./src/index.js",
     "exports": {

--- a/pdf-ui/src/components/SubmissionGovernanceAction/Steps/InformationStorageStep.jsx
+++ b/pdf-ui/src/components/SubmissionGovernanceAction/Steps/InformationStorageStep.jsx
@@ -31,7 +31,6 @@ import { IconExternalLink } from '@intersect.mbo/intersectmbo.org-icons-set';
 import { useTheme } from '@emotion/react';
 
 const InformationStorageStep = ({ proposal, handleCloseSubmissionDialog }) => {
-   
     const theme = useTheme();
     const navigate = useNavigate();
     const { walletAPI, validateMetadata } = useAppContext();
@@ -112,12 +111,17 @@ const InformationStorageStep = ({ proposal, handleCloseSubmissionDialog }) => {
         const hash = await walletAPI.createHash(jsonLd);
         setHashData(hash);
     };
-    const proposalGATypeId= proposal?.attributes?.content?.attributes.gov_action_type_id;
+    const proposalGATypeId =
+        proposal?.attributes?.content?.attributes.gov_action_type_id;
     const handleGASubmission = async () => {
         try {
+            let url = fileURL;
             setCheckingDataModal(true);
+            if (fileURL.startsWith('ipfs://')) {
+                url = `https://ipfs.io/ipfs/${fileURL.replace('ipfs://', '')}`;
+            }
             const response = await validateMetadata({
-                url: fileURL,
+                url: url,
                 hash: hashData,
                 standard: 'CIP108',
             });
@@ -135,43 +139,52 @@ const InformationStorageStep = ({ proposal, handleCloseSubmissionDialog }) => {
                         await walletAPI.buildTreasuryGovernanceAction({
                             hash: hashData,
                             url: fileURL,
-                            withdrawals: getWithdrawalsArray()
+                            withdrawals: getWithdrawalsArray(),
                         });
-                }
-                else if (parseInt(proposalGATypeId) === 3)
-                {
-                    const constitUrl = proposal?.attributes?.content?.attributes.proposal_constitution_content.data.attributes.prop_constitution_url;   
+                } else if (parseInt(proposalGATypeId) === 3) {
+                    const constitUrl =
+                        proposal?.attributes?.content?.attributes
+                            .proposal_constitution_content.data.attributes
+                            .prop_constitution_url;
                     const constiUrlHash = await getHashFromUrl(constitUrl);
                     govActionBuilder =
-                    await walletAPI.buildNewConstitutionGovernanceAction({
-                        hash: hashData,
-                        url: fileURL,
-                        constitutionUrl: constitUrl,
-                        constitutionHash: constiUrlHash
-                    //prevGovernanceActionHash: string;
-                    //prevGovernanceActionIndex: number;
-                    //scriptHash: string;
-                    });
-                }
-                else if(parseInt(proposalGATypeId) === 4)
-                { ///Motion of No Confidence
+                        await walletAPI.buildNewConstitutionGovernanceAction({
+                            hash: hashData,
+                            url: fileURL,
+                            constitutionUrl: constitUrl,
+                            constitutionHash: constiUrlHash,
+                            //prevGovernanceActionHash: string;
+                            //prevGovernanceActionIndex: number;
+                            //scriptHash: string;
+                        });
+                } else if (parseInt(proposalGATypeId) === 4) {
+                    ///Motion of No Confidence
                     govActionBuilder =
                         await walletAPI.buildNoConfidenceGovernanceAction({
                             hash: hashData,
                             url: fileURL,
                         });
-                }
-                else if(parseInt(proposalGATypeId) === 6)
-                { ///Hard Fork Initiation
+                } else if (parseInt(proposalGATypeId) === 6) {
+                    ///Hard Fork Initiation
                     govActionBuilder =
-                        await walletAPI.buildHardForkInitiationGovernanceActions({
-                            prevGovernanceActionHash: proposal?.attributes?.content?.attributes?.proposal_hard_fork_content.previous_ga_hash,
-                            prevGovernanceActionIndex: proposal?.attributes?.content?.attributes?.proposal_hard_fork_content.previous_ga_id,
-                            major: proposal?.attributes?.content?.attributes?.proposal_hard_fork_content.major,
-                            minor: proposal?.attributes?.content?.attributes?.proposal_hard_fork_content.minor,
-                            hash: hashData,
-                            url: fileURL,
-                        });
+                        await walletAPI.buildHardForkInitiationGovernanceActions(
+                            {
+                                prevGovernanceActionHash:
+                                    proposal?.attributes?.content?.attributes
+                                        ?.proposal_hard_fork_content
+                                        .previous_ga_hash,
+                                prevGovernanceActionIndex:
+                                    proposal?.attributes?.content?.attributes
+                                        ?.proposal_hard_fork_content
+                                        .previous_ga_id,
+                                major: proposal?.attributes?.content?.attributes
+                                    ?.proposal_hard_fork_content.major,
+                                minor: proposal?.attributes?.content?.attributes
+                                    ?.proposal_hard_fork_content.minor,
+                                hash: hashData,
+                                url: fileURL,
+                            }
+                        );
                 }
 
                 if (govActionBuilder) {
@@ -212,12 +225,17 @@ const InformationStorageStep = ({ proposal, handleCloseSubmissionDialog }) => {
 
     const getWithdrawalsArray = () => {
         let withdrawalsArray = [];
-        let x = proposal?.attributes?.content?.attributes?.proposal_withdrawals.forEach((withdrawal) =>
-        {
-            withdrawalsArray.push({receivingAddress:withdrawal.prop_receiving_address,amount:withdrawal.prop_amount.toString()})
-        });
+        let x =
+            proposal?.attributes?.content?.attributes?.proposal_withdrawals.forEach(
+                (withdrawal) => {
+                    withdrawalsArray.push({
+                        receivingAddress: withdrawal.prop_receiving_address,
+                        amount: withdrawal.prop_amount.toString(),
+                    });
+                }
+            );
         return withdrawalsArray;
-    }
+    };
 
     const handleDownloadJsonLD = () => {
         const blob = new Blob([JSON.stringify(jsonLdData, null, 2)], {
@@ -239,7 +257,9 @@ const InformationStorageStep = ({ proposal, handleCloseSubmissionDialog }) => {
                 throw new Error('url is not defined or null');
             }
             // Fetch the data from the URL
-            const response = (await fetch(url,{'User-Agent': "govtool-agent"}));
+            const response = await fetch(url, {
+                'User-Agent': 'govtool-agent',
+            });
             // Check if the response is successful
             if (!response.ok) {
                 throw new Error(`HTTP error! Status: ${response.status}`);

--- a/pdf-ui/src/lib/utils.js
+++ b/pdf-ui/src/lib/utils.js
@@ -64,7 +64,9 @@ export function isValidURLLength(s) {
 }
 
 export const openInNewTab = (url) => {
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    if (url.startsWith('ipfs://')) {
+        url = `https://ipfs.io/ipfs/${url.replace('ipfs://', '')}`;
+    } else if (!url.startsWith('http://') && !url.startsWith('https://')) {
         url = 'https://' + url;
     }
     const newWindow = window.open(url, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## List of changes

-  Fix submitting governance action with ipfs metadata url fails due to unsupported url scheme (#3979)

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/#3979)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
