### PR TITLE
fix: simplify handling of proposal constitution content in handleUrlC…

### DIFF
--- a/pdf-ui/CHANGELOG.md
+++ b/pdf-ui/CHANGELOG.md
@@ -8,35 +8,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [v1.0.14-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.14-beta) 2025-09-10
+
+-  fix: Proposal form resets guardrails script data on Constitution URL change. #4041
+
 ## [v1.0.13-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.13-beta) 2025-08-11
+
 -   Add # to Proposal Details WithdrawalsManager
 
 ## [v1.0.12-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.12-beta) 2025-08-08
--   feat:  Update Treasury Proposal Amount Field to Accept ADA Instead of Lovelace #4000
+
+-   feat: Update Treasury Proposal Amount Field to Accept ADA Instead of Lovelace #4000
 
 ## [v1.0.11-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.11-beta) 2025-07-31
+
 -   feat: Implement proxy data fetching and enhance error handling in InformationStorageStep
 -   feat: Add getViaProxy function to facilitate API requests through the proxy
 -   fix: Update User-Agent header in proxy controller for consistency
 -   refactor: Improve proposal data handling in ConstitutionManager and EditProposalDialog
 
 ## [v1.0.10-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.10-beta) 2025-07-29
+
 -   Submitting Governance Action with IPFS Metadata URL Fails Due to Unsupported URL Scheme #3979
 
 ## [v1.0.9-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.9-beta) 2025-07-03
+
 -   Support IPFS Links for Governance Action Submissions #3851
 
 ## [v1.0.8-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.8-beta) 2025-06-30
+
 -   Align Vote link
 
 ## [v1.0.7-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.7-beta) 2025-06-30
+
 -   Align Vote link
-- Fix: "Verify Yourself to submit" Message Displayed on Already Submitted Proposals #3857
+-   Fix: "Verify Yourself to submit" Message Displayed on Already Submitted Proposals #3857
 
 ## [v1.0.6-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.6-beta) 2025-06-30
+
 -   Align Vote link
 
 ## [v1.0.5-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.5-beta) 2025-06-30
+
 -   Align Vote link
 
 ## [v1.0.4-beta](https://www.npmjs.com/package/@intersect.mbo/pdf-ui/v/1.0.4-beta) 2025-06-30

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@intersect.mbo/pdf-ui",
-    "version": "1.0.13-beta",
+    "version": "1.0.14-beta",
     "description": "Proposal discussion ui",
     "main": "./src/index.js",
     "exports": {

--- a/pdf-ui/src/components/CreationGoveranceAction/ConstitutionManager.jsx
+++ b/pdf-ui/src/components/CreationGoveranceAction/ConstitutionManager.jsx
@@ -54,12 +54,7 @@ const ConstitutionManager = ({
     };
     const handleUrlChange = (url_text) => {
         constcheckLinkValue(url_text, 'prop_constitution_url');
-        let pk = { ...proposalData.proposal_constitution_content }
-            ? {
-                  ...proposalData.proposal_constitution_content?.data
-                      ?.attributes,
-              }
-            : {};
+        let pk = proposalData.proposal_constitution_content || {};
         pk.prop_constitution_url = url_text;
         setProposalData({ ...proposalData, proposal_constitution_content: pk });
     };


### PR DESCRIPTION
## List of changes

- Fix Proposal form resets guardrails script data on Constitution URL change. #4041

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/4041)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
