### PR TITLE
fix(security): remove open SSRF proxy and add endpoint validation

### DIFF
--- a/backend/src/api/govtool-proxy/controllers/govtool-proxy.js
+++ b/backend/src/api/govtool-proxy/controllers/govtool-proxy.js
@@ -5,30 +5,56 @@ module.exports = {
     try {
       const baseUrl = process.env.GOVTOOL_API_BASE_URL;
 
-      // Uzmite endpoint iz query parametara
+      if (!baseUrl) {
+        return ctx.throw(500, 'GOVTOOL_API_BASE_URL is not configured');
+      }
+
       const { endpoint } = ctx.request.query;
 
-      if (!endpoint) {
-        return ctx.throw(400, 'Endpoint parametar je obavezan');
+      if (!endpoint || typeof endpoint !== 'string' || endpoint.trim() === '') {
+        return ctx.throw(400, 'Endpoint parameter is required');
       }
 
-      // Spojite base URL i endpoint
-      const fullUrl = `${baseUrl}/${endpoint}`;
-console.log(fullUrl);
-      // Provera da li je URL validan (opciono)
+      // Reject absolute URLs to prevent SSRF
+      if (/^https?:\/\//i.test(endpoint)) {
+        return ctx.throw(400, 'Absolute URLs are not allowed');
+      }
+
+      // Reject protocol-relative URLs
+      if (/^\/\//.test(endpoint)) {
+        return ctx.throw(400, 'Protocol-relative URLs are not allowed');
+      }
+
+      // Reject path traversal sequences
+      if (endpoint.includes('..')) {
+        return ctx.throw(400, 'Path traversal is not allowed');
+      }
+
+      // Reject null bytes and backslashes
+      if (endpoint.includes('\0') || endpoint.includes('\\')) {
+        return ctx.throw(400, 'Invalid characters in endpoint');
+      }
+
+      const fullUrl = `${baseUrl.replace(/\/$/, '')}/${endpoint}`;
+
       try {
-        new URL(fullUrl); // Provera da li je URL validan
+        new URL(fullUrl);
       } catch (error) {
-        return ctx.throw(400, 'Nevalidan URL');
+        return ctx.throw(400, 'Invalid URL');
       }
 
-      // Pozovite eksterni API
-      const response = await axios.get(fullUrl);
+      const headers = {};
+      if (process.env.GOVTOOL_API_TOKEN) {
+        headers.Authorization = `Bearer ${process.env.GOVTOOL_API_TOKEN}`;
+      }
 
-      // Vratite podatke klijentu
+      const response = await axios.get(fullUrl, { headers });
+
       ctx.send(response.data);
     } catch (error) {
-      ctx.throw(500, 'Greška pri preuzimanju podataka sa eksternog API-ja', { error });
+      if (error.status) throw error;
+      strapi.log.error('GovTool proxy error:', error);
+      ctx.throw(500, 'Error fetching data from external API', { error });
     }
   },
 };

--- a/backend/src/api/proxy/controllers/proxy.js
+++ b/backend/src/api/proxy/controllers/proxy.js
@@ -1,41 +1,69 @@
 "use strict";
 const axios = require("axios");
 
-module.exports = {
-  // POST /proxy
-  async forward(ctx) {
-    try {
-      const {
-        url,
-        method = "GET",
-        data = {},
-        params = {},
-        headers = {},
-      } = ctx.request.body;
-      const response = await axios({ url, method, data, params, headers });
-      ctx.send({ status: response.status, data: response.data });
-    } catch (error) {
-      strapi.log.error("Proxy error:", error);
-      ctx.status = error.response?.status || 500;
-      ctx.body = {
-        error: error.message,
-        details: error.response?.data || null,
-      };
-    }
-  },
+/**
+ * Validates that an endpoint path is safe and cannot be used for SSRF or path traversal.
+ * @param {string} endpoint - The endpoint path to validate
+ * @returns {{ valid: boolean, error?: string }}
+ */
+function validateEndpoint(endpoint) {
+  if (!endpoint || typeof endpoint !== "string" || endpoint.trim() === "") {
+    return { valid: false, error: "Endpoint is required" };
+  }
 
+  // Reject absolute URLs to prevent SSRF
+  if (/^https?:\/\//i.test(endpoint)) {
+    return { valid: false, error: "Absolute URLs are not allowed" };
+  }
+
+  // Reject protocol-relative URLs
+  if (/^\/\//.test(endpoint)) {
+    return { valid: false, error: "Protocol-relative URLs are not allowed" };
+  }
+
+  // Reject path traversal sequences
+  if (endpoint.includes("..")) {
+    return { valid: false, error: "Path traversal is not allowed" };
+  }
+
+  // Reject null bytes
+  if (endpoint.includes("\0")) {
+    return { valid: false, error: "Null bytes are not allowed" };
+  }
+
+  // Reject backslashes (Windows path traversal)
+  if (endpoint.includes("\\")) {
+    return { valid: false, error: "Backslashes are not allowed" };
+  }
+
+  return { valid: true };
+}
+
+module.exports = {
   // GET /proxy/govtool/:endpoint*
   async getGovtoolData(ctx) {
     try {
       const endpoint = ctx.params.endpoint;
-      if (!endpoint) return ctx.badRequest("Endpoint is required");
+      const validation = validateEndpoint(endpoint);
+      if (!validation.valid) {
+        return ctx.badRequest(validation.error);
+      }
+
       const baseUrl = process.env.GOVTOOL_API_BASE_URL;
+      if (!baseUrl) {
+        return ctx.internalServerError("GOVTOOL_API_BASE_URL is not configured");
+      }
+
       const fullUrl = `${baseUrl.replace(/\/$/, "")}/${endpoint}`;
+
+      const headers = {};
+      if (process.env.GOVTOOL_API_TOKEN) {
+        headers.Authorization = `Bearer ${process.env.GOVTOOL_API_TOKEN}`;
+      }
+
       const response = await axios.get(fullUrl, {
         params: ctx.query,
-        headers: {
-          // Authorization: `Bearer ${process.env.GOVTOOL_API_TOKEN}`,
-        },
+        headers,
       });
 
       ctx.send({ status: response.status, data: response.data });
@@ -52,16 +80,27 @@ module.exports = {
   async postGovtoolData(ctx) {
     try {
       const endpoint = ctx.params.endpoint;
-      if (!endpoint) return ctx.badRequest("Endpoint is required");
+      const validation = validateEndpoint(endpoint);
+      if (!validation.valid) {
+        return ctx.badRequest(validation.error);
+      }
 
       const baseUrl = process.env.GOVTOOL_API_BASE_URL;
+      if (!baseUrl) {
+        return ctx.internalServerError("GOVTOOL_API_BASE_URL is not configured");
+      }
+
       const fullUrl = `${baseUrl.replace(/\/$/, "")}/${endpoint}`;
 
+      const headers = {
+        "Content-Type": "application/json",
+      };
+      if (process.env.GOVTOOL_API_TOKEN) {
+        headers.Authorization = `Bearer ${process.env.GOVTOOL_API_TOKEN}`;
+      }
+
       const response = await axios.post(fullUrl, ctx.request.body, {
-        headers: {
-          "Content-Type": "application/json",
-          // Authorization: `Bearer ${process.env.GOVTOOL_API_TOKEN}`,
-        },
+        headers,
       });
 
       ctx.send({ status: response.status, data: response.data });

--- a/backend/src/api/proxy/routes/proxy.js
+++ b/backend/src/api/proxy/routes/proxy.js
@@ -3,31 +3,22 @@
 module.exports = {
   routes: [
     {
-      method: 'POST',
-      path: '/proxy',
-      handler: 'proxy.forward',
+      method: 'GET',
+      path: '/proxy/govtool/:endpoint*',
+      handler: 'proxy.getGovtoolData',
       config: {
         roles: ['authenticated', 'public'],
         auth: false
       },
     },
     {
-      method: 'GET',
-      path: '/proxy/govtool/:endpoint*',
-      handler: 'proxy.getGovtoolData',
-      config: {
-            roles: ['authenticated', 'public'],
-            auth: false      
-        },
-    },
-    {
       method: 'POST',
       path: '/proxy/govtool/:endpoint*',
       handler: 'proxy.postGovtoolData',
       config: {
-            roles: ['authenticated', 'public'],
-            auth: false      
-        },
+        roles: ['authenticated', 'public'],
+        auth: false
+      },
     },
   ],
 };


### PR DESCRIPTION
## Summary

Fixes IntersectMBO/govtool#4168 — Unauthenticated Open SSRF Proxy (CVSS 9.1 Critical)

### Vulnerability

The `POST /api/proxy` endpoint was a fully open, unauthenticated HTTP proxy. Any attacker could send a single POST request and make the server fetch any URL, controlling the HTTP method, headers, query parameters, and request body. This enabled:

- **Cloud credential theft** (AWS/GCP/Azure instance metadata)
- **Internal network traversal** (database, internal APIs)
- **Arbitrary request forgery** (POST/PUT/DELETE to internal services)

### Changes

**Critical fix — Remove open SSRF proxy:**
- Removed the `forward()` handler from `backend/src/api/proxy/controllers/proxy.js`
- Removed the `POST /proxy` route from `backend/src/api/proxy/routes/proxy.js`
- This endpoint was dead code — the frontend only uses `/api/proxy/govtool/...` routes

**Hardening — Validate govtool proxy endpoints:**
- Added `validateEndpoint()` helper that rejects:
  - Absolute URLs (`http://`, `https://`)
  - Protocol-relative URLs (`//`)
  - Path traversal sequences (`..`)
  - Null bytes and backslashes
- Applied validation to both `getGovtoolData` and `postGovtoolData` handlers
- Added `GOVTOOL_API_BASE_URL` null check with proper error response
- Enabled Authorization header forwarding when `GOVTOOL_API_TOKEN` is configured

**Hardening — Fix govtool-proxy endpoint:**
- Applied the same SSRF protections to `backend/src/api/govtool-proxy/controllers/govtool-proxy.js`
- Removed `console.log(fullUrl)` that leaked URLs to server logs
- Translated Serbian comments to English

### Impact

| Before | After |
|--------|-------|
| Any user can proxy to any URL | Proxy only forwards to configured `GOVTOOL_API_BASE_URL` |
| `POST /api/proxy` accepts arbitrary URLs | Route removed entirely |
| Path traversal possible via endpoint param | `..`, `\`, null bytes, absolute URLs all rejected |
| No upstream auth headers | `GOVTOOL_API_TOKEN` forwarded when configured |

### Testing

The SSRF mitigation can be verified with these curl commands (should all return 400):

```bash
curl -X POST https://<host>/api/proxy -d "{}" 
# Expected: 404 (route removed)

curl https://<host>/api/proxy/govtool/http://169.254.169.254/latest/meta-data/
# Expected: 400 "Absolute URLs are not allowed"

curl https://<host>/api/proxy/govtool/../../etc/passwd
# Expected: 400 "Path traversal is not allowed"

curl https://<host>/api/proxy/govtool/\\internal-host:8080/
# Expected: 400 "Backslashes are not allowed"
```

Fixes #4168