### PR TITLE
fix: remove open SSRF proxy and add auth to govtool endpoints

### DIFF
--- a/backend/src/api/proxy/controllers/proxy.js
+++ b/backend/src/api/proxy/controllers/proxy.js
@@ -1,35 +1,42 @@
 "use strict";
 const axios = require("axios");
 
-module.exports = {
-  // POST /proxy
-  async forward(ctx) {
-    try {
-      const {
-        url,
-        method = "GET",
-        data = {},
-        params = {},
-        headers = {},
-      } = ctx.request.body;
-      const response = await axios({ url, method, data, params, headers });
-      ctx.send({ status: response.status, data: response.data });
-    } catch (error) {
-      strapi.log.error("Proxy error:", error);
-      ctx.status = error.response?.status || 500;
-      ctx.body = {
-        error: error.message,
-        details: error.response?.data || null,
-      };
-    }
-  },
+/**
+ * Proxy controller — scoped to GovTool API only.
+ *
+ * The generic POST /proxy endpoint (forward handler) has been removed.
+ * It was an unauthenticated open SSRF proxy that allowed any caller to
+ * make the server fetch arbitrary URLs, including cloud metadata and
+ * internal services.  See issue #4168.
+ *
+ * The remaining endpoints forward requests exclusively to the
+ * GOVTOOL_API_BASE_URL configured in the environment.
+ */
 
+// Allowed path segments for the GovTool proxy.
+// Reject any endpoint containing ".." or starting with "/" to prevent
+// URL traversal and host-relative redirects.
+const BLOCKED_PATTERNS = [/\.\./, /^\/+/, /:\/\//];
+
+function validateEndpoint(endpoint) {
+  if (!endpoint) return false;
+  return !BLOCKED_PATTERNS.some((rx) => rx.test(endpoint));
+}
+
+module.exports = {
   // GET /proxy/govtool/:endpoint*
   async getGovtoolData(ctx) {
     try {
       const endpoint = ctx.params.endpoint;
       if (!endpoint) return ctx.badRequest("Endpoint is required");
+      if (!validateEndpoint(endpoint)) {
+        return ctx.badRequest("Invalid endpoint path");
+      }
       const baseUrl = process.env.GOVTOOL_API_BASE_URL;
+      if (!baseUrl) {
+        strapi.log.error("GOVTOOL_API_BASE_URL is not configured");
+        return ctx.internalServerError("Proxy target not configured");
+      }
       const fullUrl = `${baseUrl.replace(/\/$/, "")}/${endpoint}`;
       const response = await axios.get(fullUrl, {
         params: ctx.query,
@@ -53,8 +60,15 @@ module.exports = {
     try {
       const endpoint = ctx.params.endpoint;
       if (!endpoint) return ctx.badRequest("Endpoint is required");
-
+      if (!validateEndpoint(endpoint)) {
+        return ctx.badRequest("Invalid endpoint path");
+      }
       const baseUrl = process.env.GOVTOOL_API_BASE_URL;
+      if (!baseUrl) {
+        strapi.log.error("GOVTOOL_API_BASE_URL is not configured");
+        return ctx.internalServerError("Proxy target not configured");
+      }
+
       const fullUrl = `${baseUrl.replace(/\/$/, "")}/${endpoint}`;
 
       const response = await axios.post(fullUrl, ctx.request.body, {

--- a/backend/src/api/proxy/routes/proxy.js
+++ b/backend/src/api/proxy/routes/proxy.js
@@ -2,32 +2,25 @@
 
 module.exports = {
   routes: [
-    {
-      method: 'POST',
-      path: '/proxy',
-      handler: 'proxy.forward',
-      config: {
-        roles: ['authenticated', 'public'],
-        auth: false
-      },
-    },
+    // NOTE: The generic POST /proxy (forward) route has been removed.
+    // It was an unauthenticated open SSRF proxy. See issue #4168.
     {
       method: 'GET',
       path: '/proxy/govtool/:endpoint*',
       handler: 'proxy.getGovtoolData',
       config: {
-            roles: ['authenticated', 'public'],
-            auth: false      
-        },
+        roles: ['authenticated'],
+        auth: true
+      },
     },
     {
       method: 'POST',
       path: '/proxy/govtool/:endpoint*',
       handler: 'proxy.postGovtoolData',
       config: {
-            roles: ['authenticated', 'public'],
-            auth: false      
-        },
+        roles: ['authenticated'],
+        auth: true
+      },
     },
   ],
 };


### PR DESCRIPTION
Fixes IntersectMBO/govtool#4168

## Problem
The `POST /api/proxy` endpoint was an unauthenticated open SSRF proxy. Any anonymous caller could make the server fetch arbitrary URLs, including:
- Cloud metadata (169.254.169.254) → IAM credential theft
- Internal services (database:5432, localhost:1337) → internal network traversal
- Arbitrary POST requests → request forgery against internal APIs

The endpoint was dead code — the frontend only uses `/api/proxy/govtool/...` endpoints.

## Changes
1. **Remove `forward()` handler** — the generic POST /proxy endpoint that was the SSRF vector
2. **Remove `POST /proxy` route** — from routes configuration
3. **Add authentication** — set `auth: true` on govtool proxy endpoints (previously `auth: false`)
4. **Add URL validation** — reject endpoint paths containing `..`, leading `/`, or `://` to prevent traversal
5. **Add config check** — return 500 if `GOVTOOL_API_BASE_URL` is not configured

## Testing
- Verify `POST /api/proxy` returns 404 (route removed)
- Verify `GET /api/proxy/govtool/test` requires authentication
- Verify `POST /api/proxy/govtool/test` requires authentication
- Verify path traversal attempts (e.g., `../../etc/passwd`) are rejected
- Verify normal govtool proxy requests still work with valid auth