### PR TITLE
Update workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -4,6 +4,10 @@ run-name: Publish by @${{ github.actor }}
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -13,27 +17,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          scope: "@intersect.mbo"
-
-      - name: Authenticate with Scoped NPM
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          registry-url: "https://registry.npmjs.org"
-          scope: "@intersect.mbo"
-        run: |
-          npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          npm config set scope "@intersect.mbo"
-          npm whoami
-
-      - name: Check NPM Authentication
-        run: npm whoami
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/pdf-ui/package.json
+++ b/pdf-ui/package.json
@@ -2,6 +2,11 @@
     "name": "@intersect.mbo/pdf-ui",
     "version": "1.0.16-beta",
     "description": "Proposal discussion ui",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/IntersectMBO/govtool-proposal-pillar.git",
+        "directory": "pdf-ui"
+    },
     "main": "./src/index.js",
     "exports": {
         ".": {


### PR DESCRIPTION
## List of changes

- Remove token based npm package publishing workflow
- Adds workflow for  oidc based npm trusted publishing

## Checklist

- [x] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool-voting-pillar/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
