### PR TITLE
Fix npm publish workflow for beta package

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -32,6 +32,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag beta
         env:
           NODE_OPTIONS: --max_old_space_size=8192


### PR DESCRIPTION
## Summary
- Use an ESM default export in the Rollup config so Rollup 4 can load it
- Publish prerelease package versions with the npm beta dist-tag

## Verification
- cd pdf-ui && npm ci
- cd pdf-ui && npm run build:rollup
- cd pdf-ui && npm publish --dry-run --access public --tag beta

The dry-run completed successfully and reported publishing @intersect.mbo/pdf-ui@1.0.16-beta with tag beta.